### PR TITLE
Don't throw NullReferenceException when GetCurrentMedia is called before EndInit()

### DIFF
--- a/src/Vlc.DotNet.Forms/VlcControl.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.cs
@@ -107,6 +107,7 @@ namespace Vlc.DotNet.Forms
 
         public VlcMedia GetCurrentMedia()
         {
+            EndInit();
             return myVlcMediaPlayer.GetMedia();
         }
 


### PR DESCRIPTION
Now it will return null.