### PR TITLE
fix Disposing with wrong VlcLibDirectory

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/InteropObjectInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/InteropObjectInstance.cs
@@ -19,12 +19,13 @@ namespace Vlc.DotNet.Core.Interops.Signatures
                 return;
             myIsDisposing = true;
             Dispose(true);
+
+            GC.SuppressFinalize(this);
         }
 
-        public virtual void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             Pointer = IntPtr.Zero;
-            GC.SuppressFinalize(this);
         }
 
         ~InteropObjectInstance()

--- a/src/Vlc.DotNet.Core.Interops/Signatures/InteropObjectInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/InteropObjectInstance.cs
@@ -47,6 +47,9 @@ namespace Vlc.DotNet.Core.Interops.Signatures
 
         public static bool operator ==(InteropObjectInstance a, InteropObjectInstance b)
         {
+            if (Equals(a, null) || Equals(b, null))
+                return Equals(a, b);
+
             return a.Pointer.Equals(b.Pointer);
         }
 

--- a/src/Vlc.DotNet.Core.Interops/VlcEventManagerInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcEventManagerInstance.cs
@@ -12,7 +12,7 @@ namespace Vlc.DotNet.Core.Interops
             myManager = manager;
         }
 
-        public override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
         }

--- a/src/Vlc.DotNet.Core.Interops/VlcInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcInstance.cs
@@ -12,7 +12,7 @@ namespace Vlc.DotNet.Core.Interops
             myManager = manager;
         }
 
-        public override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (Pointer != IntPtr.Zero)
                 myManager.ReleaseInstance(this);

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.cs
@@ -29,7 +29,9 @@ namespace Vlc.DotNet.Core.Interops
 
         public override void Dispose(bool disposing)
         {
-            myVlcInstance.Dispose();
+            if (myVlcInstance != null)
+                myVlcInstance.Dispose();
+
             if (myAllInstance.ContainsValue(this))
             {
                 foreach (var kv in new Dictionary<DirectoryInfo, VlcManager>(myAllInstance))

--- a/src/Vlc.DotNet.Core.Interops/VlcMediaInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcMediaInstance.cs
@@ -12,7 +12,7 @@ namespace Vlc.DotNet.Core.Interops
             myManager = manager;
         }
 
-        public override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (Pointer != IntPtr.Zero)
                 myManager.ReleaseMedia(this);

--- a/src/Vlc.DotNet.Core.Interops/VlcMediaPlayerInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcMediaPlayerInstance.cs
@@ -21,7 +21,9 @@ namespace Vlc.DotNet.Core.Interops
 
         public static implicit operator IntPtr(VlcMediaPlayerInstance instance)
         {
-            return instance.Pointer;
+            return instance != null
+                ? instance.Pointer
+                : IntPtr.Zero;
         }
     }
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcMediaPlayerInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcMediaPlayerInstance.cs
@@ -12,7 +12,7 @@ namespace Vlc.DotNet.Core.Interops
             myManager = manager;
         }
 
-        public override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (Pointer != IntPtr.Zero)
                 myManager.ReleaseMediaPlayer(this);


### PR DESCRIPTION
VlcControl throw unhandled exception while Disposing if:
1. set wrong VlcDirectory
2. catch exception which Play() metod throw
3. close app