### PR TITLE
Fix exception thrown when disposing of a vlc control (was attempting …

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/VlcMediaInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcMediaInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
@@ -6,16 +7,35 @@ namespace Vlc.DotNet.Core.Interops
     public sealed class VlcMediaInstance : InteropObjectInstance
     {
         private readonly VlcManager myManager;
+        static readonly Dictionary<IntPtr, int> sInstanceCount
+            = new Dictionary<IntPtr, int>();
 
-        internal VlcMediaInstance(VlcManager manager, IntPtr pointer) : base(pointer)
+        internal VlcMediaInstance(VlcManager manager, IntPtr pointer)
+            : base(pointer)
         {
             myManager = manager;
+            if (pointer != IntPtr.Zero)
+            {
+                // keep a reference count for the media instance
+                if (!sInstanceCount.ContainsKey(pointer))
+                    sInstanceCount[pointer] = 0;
+                else
+                    sInstanceCount[pointer] = sInstanceCount[pointer] + 1;
+            }
         }
 
         protected override void Dispose(bool disposing)
         {
             if (Pointer != IntPtr.Zero)
-                myManager.ReleaseMedia(this);
+            {
+                // only release the instance if no more references
+                if (sInstanceCount[this.Pointer] > 0)
+                {
+                    sInstanceCount[this.Pointer] = sInstanceCount[this.Pointer] - 1;
+                    if (sInstanceCount[this.Pointer] == 0)
+                        myManager.ReleaseMedia(this);
+                }
+            }
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
…to double release a vlc media instance; added reference counting guard).