### PR TITLE
Patch for issue with Wpf control not automatically stretching/shrinki…

### DIFF
--- a/src/Samples/Vlc.DotNet.Wpf.Samples/Vlc.DotNet.Wpf.Samples - CLR 2 - .Net 3.5.csproj
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/Vlc.DotNet.Wpf.Samples - CLR 2 - .Net 3.5.csproj
@@ -62,6 +62,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/Vlc.DotNet.Wpf.Samples - CLR 4 - .Net 4.0.csproj
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/Vlc.DotNet.Wpf.Samples - CLR 4 - .Net 4.0.csproj
@@ -64,6 +64,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/Vlc.DotNet.Wpf.Samples - CLR 4 - .Net 4.5.csproj
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/Vlc.DotNet.Wpf.Samples - CLR 4 - .Net 4.5.csproj
@@ -68,6 +68,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/src/Vlc.DotNet.Wpf/Vlc.DotNet.Wpf - CLR 4 - .Net 4.0.csproj
+++ b/src/Vlc.DotNet.Wpf/Vlc.DotNet.Wpf - CLR 4 - .Net 4.0.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Vlc.DotNet.Core\Properties\AssemblyInfo.Common.cs">

--- a/src/Vlc.DotNet.Wpf/Vlc.DotNet.Wpf - CLR 4 - .Net 4.5.csproj
+++ b/src/Vlc.DotNet.Wpf/Vlc.DotNet.Wpf - CLR 4 - .Net 4.5.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Windows.Presentation" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Vlc.DotNet.Core.Interops\Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.5.csproj">

--- a/src/Vlc.DotNet.Wpf/VlcControl.cs
+++ b/src/Vlc.DotNet.Wpf/VlcControl.cs
@@ -2,31 +2,18 @@ using System;
 using System.Runtime.InteropServices;
 using System.Windows.Interop;
 using Vlc.DotNet.Core.Interops;
+using System.Windows.Forms.Integration;
 
 namespace Vlc.DotNet.Wpf
 {
-    public class VlcControl : HwndHost 
+    public class VlcControl : WindowsFormsHost
     {
         public Forms.VlcControl MediaPlayer { get; private set; }
 
         public VlcControl()
         {
             MediaPlayer = new Forms.VlcControl();
-        }
-
-        protected override HandleRef BuildWindowCore(HandleRef hwndParent)
-        {
-            Win32Interops.SetParent(MediaPlayer.Handle, hwndParent.Handle);
-            return new HandleRef(this, MediaPlayer.Handle);
-        }
-
-        protected override void DestroyWindowCore(HandleRef hwnd)
-        {
-            if(MediaPlayer == null)
-                return;
-            Win32Interops.SetParent(IntPtr.Zero, hwnd.Handle);
-            MediaPlayer.Dispose();
-            MediaPlayer = null;
+            this.Child = MediaPlayer; 
         }
     }
 }


### PR DESCRIPTION
…ng with container window after Stop() method is called or player reaches end of clip.


See https://github.com/ZeBobo5/Vlc.DotNet/issues/80