### PR TITLE
Fixed ToInt32() call OverflowException crash with VLC 64 bits

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetMediaTracksInformations.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetMediaTracksInformations.cs
@@ -19,7 +19,7 @@ namespace Vlc.DotNet.Core.Interops
             for (int index = 0; index < cpt; index++)
             {
                 result[index] = (MediaTrackInfosStructure)Marshal.PtrToStructure(buffer, typeof(MediaTrackInfosStructure));
-                buffer = new IntPtr(buffer.ToInt32() + Marshal.SizeOf(typeof(MediaTrackInfosStructure)));
+                buffer = new IntPtr(buffer.ToInt64() + Marshal.SizeOf(typeof(MediaTrackInfosStructure)));
             }
             Free(fullBuffer);
             return result;


### PR DESCRIPTION
This line crashes when using VLC 2.2. 64 bits, at least on Windows 8.1. Always using ToInt64() should always work, I think.