### PR TITLE
Make TakeSnapshot() command accessible from VlcControl

### DIFF
--- a/src/Vlc.DotNet.Forms/VlcControl.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.cs
@@ -120,6 +120,12 @@ namespace Vlc.DotNet.Forms
             EndInit();
             return myVlcMediaPlayer.GetMedia();
         }
+        
+        public void TakeSnapshot(string fileName) 
+        {
+            FileInfo fileInfo = new FileInfo(fileName);
+            myVlcMediaPlayer.TakeSnapshot(fileInfo);
+        }
 
         public float Position
         {


### PR DESCRIPTION
TakeSnapshot() functionality has been implemented into Vlc.DotNet, but TakeSnapshot() function is not accessible from VlcControl. Added method to access snapshot functionality from VlcControl.