### PR TITLE
Update VlcMediaPlayer.Events.EndReached.cs

### DIFF
--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.EndReached.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.EndReached.cs
@@ -10,7 +10,7 @@ namespace Vlc.DotNet.Core
 
         private void OnMediaPlayerEndReachedInternal(IntPtr ptr)
         {
-            ResetFromMedia();
+            //ResetFromMedia();
             OnMediaPlayerEndReached();
         }
 


### PR DESCRIPTION
- Comment out function "ResetFromMedia" to avoid memory allocation after media reached end (issue #81)