### PR TITLE
unhandled exception 'System.ArgumentException' on close

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/VlcManager.IsPlaying.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.IsPlaying.cs
@@ -7,8 +7,13 @@ namespace Vlc.DotNet.Core.Interops
     {
         public bool IsPlaying(VlcMediaPlayerInstance mediaPlayerInstance)
         {
-            if (mediaPlayerInstance == IntPtr.Zero)
-                throw new ArgumentException("Media player instance is not initialized.");
+            if (mediaPlayerInstance == IntPtr.Zero) return false;
+            //This seems to be called multiple time
+            //Eventually throwing an uncaught exception on close
+            //An unhandled exception of type 'System.ArgumentException' occurred in Vlc.DotNet.Core.Interops.dll
+            //Additional information: Media player instance is not initialized.
+            //if (mediaPlayerInstance == IntPtr.Zero)
+            //    throw new ArgumentException("Media player instance is not initialized.");
             return GetInteropDelegate<IsPlaying>().Invoke(mediaPlayerInstance) == 1;
         }
     }


### PR DESCRIPTION
Fix the unhandled exception 'System.ArgumentException' occurred in Vlc.DotNet.Core.Interops.dll thrown on close.