### PR TITLE
Subtitle marshalling error

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_get_track_description.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_get_track_description.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_audio_get_track_description")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate TrackDescriptionStructure GetAudioTracksDescriptions(IntPtr mediaPlayerInstance);
+    internal delegate IntPtr GetAudioTracksDescriptions(IntPtr mediaPlayerInstance);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_track_description_list_release.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_track_description_list_release.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Vlc.DotNet.Core.Interops.Signatures
 {
@@ -7,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_track_description_list_release")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void ReleaseTrackDescription(TrackDescriptionStructure trackDescription);
+    internal delegate void ReleaseTrackDescription(IntPtr trackDescription);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_get_spu_description.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_get_spu_description.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_get_spu_description")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate TrackDescriptionStructure GetVideoSpuDescription(IntPtr mediaPlayerInstance);
+    internal delegate IntPtr GetVideoSpuDescription(IntPtr mediaPlayerInstance);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_get_track_description.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_get_track_description.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_get_track_description")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate TrackDescriptionStructure GetVideoTracksDescriptions(IntPtr mediaPlayerInstance);
+    internal delegate IntPtr GetVideoTracksDescriptions(IntPtr mediaPlayerInstance);
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioTracksDescriptions.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioTracksDescriptions.cs
@@ -5,7 +5,7 @@ namespace Vlc.DotNet.Core.Interops
 {
     public sealed partial class VlcManager
     {
-        public TrackDescriptionStructure GetAudioTracksDescriptions(VlcMediaPlayerInstance mediaPlayerInstance)
+        public IntPtr GetAudioTracksDescriptions(VlcMediaPlayerInstance mediaPlayerInstance)
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetVideoSpuDescription.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetVideoSpuDescription.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
 {
     public sealed partial class VlcManager
     {
-        public TrackDescriptionStructure GetVideoSpuDescription(VlcMediaPlayerInstance mediaPlayerInstance)
+        public IntPtr GetVideoSpuDescription(VlcMediaPlayerInstance mediaPlayerInstance)
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetVideoTracksDescriptions.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetVideoTracksDescriptions.cs
@@ -5,7 +5,7 @@ namespace Vlc.DotNet.Core.Interops
 {
     public sealed partial class VlcManager
     {
-        public TrackDescriptionStructure GetVideoTracksDescriptions(VlcMediaPlayerInstance mediaPlayerInstance)
+        public IntPtr GetVideoTracksDescriptions(VlcMediaPlayerInstance mediaPlayerInstance)
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.ReleaseTrackDescription.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.ReleaseTrackDescription.cs
@@ -5,7 +5,7 @@ namespace Vlc.DotNet.Core.Interops
 {
     public sealed partial class VlcManager
     {
-        public void ReleaseTrackDescription(TrackDescriptionStructure trackDescription)
+        public void ReleaseTrackDescription(IntPtr trackDescription)
         {
             GetInteropDelegate<ReleaseTrackDescription>().Invoke(trackDescription);
         }

--- a/src/Vlc.DotNet.Core/TrackDescription.cs
+++ b/src/Vlc.DotNet.Core/TrackDescription.cs
@@ -16,14 +16,14 @@ namespace Vlc.DotNet.Core
             Name = name;
         }
 
-        internal static List<TrackDescription> GetSubTrackDescription(TrackDescriptionStructure module)
+        internal static List<TrackDescription> GetSubTrackDescription(IntPtr moduleRef)
         {
             var result = new List<TrackDescription>();
-            result.Add(new TrackDescription(module.Id, module.Name));
-            if (module.NextTrackDescription != IntPtr.Zero)
+            if (moduleRef != IntPtr.Zero)
             {
-                TrackDescriptionStructure nextModule = (TrackDescriptionStructure)Marshal.PtrToStructure(module.NextTrackDescription, typeof(TrackDescriptionStructure));
-                var data = GetSubTrackDescription(nextModule);
+                var module = (TrackDescriptionStructure)Marshal.PtrToStructure(moduleRef, typeof(TrackDescriptionStructure));
+                result.Add(new TrackDescription(module.Id, module.Name));
+                var data = GetSubTrackDescription(module.NextTrackDescription);
                 result.AddRange(data);
             }
             return result;

--- a/src/Vlc.DotNet.Core/TrackDescription.cs
+++ b/src/Vlc.DotNet.Core/TrackDescription.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core
@@ -22,7 +23,8 @@ namespace Vlc.DotNet.Core
             if (moduleRef != IntPtr.Zero)
             {
                 var module = (TrackDescriptionStructure)Marshal.PtrToStructure(moduleRef, typeof(TrackDescriptionStructure));
-                result.Add(new TrackDescription(module.Id, module.Name));
+                var name = Encoding.UTF8.GetString(Encoding.Default.GetBytes(module.Name));
+                result.Add(new TrackDescription(module.Id, name));
                 var data = GetSubTrackDescription(module.NextTrackDescription);
                 result.AddRange(data);
             }


### PR DESCRIPTION
Changed from struct to pointer in the vlclib api mapping regarding track description structure, since this raised a pinvoke exception of bad mapping on the methods that returned the struct.

Also fixed an issue with the encoding of the name contained in the string, since with vlc 2.4 on windows 7, the UTF-8 encoded name property of the struct is marshalled as ansi. Switching to unicode gives asian characters.

All issues were detected and fixed only on .net 4.5 since this is the version I am using. As such I am unsure if these issues exist on the other .net framework versions.