### PR TITLE
Added stream playing. Requires vlc-3.0.0-git

### DIFF
--- a/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
+++ b/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
@@ -38,8 +38,9 @@ namespace Vlc.DotNet.Forms.Samples
 
         private void OnButtonPlayClicked(object sender, EventArgs e)
         {
-            myVlcControl.Play(new Uri("http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi"));
+            //myVlcControl.Play(new Uri("http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi"));
             //myVlcControl.Play(new FileInfo(@"..\..\..\Vlc.DotNet\Samples\Videos\BBB trailer.mov"));
+            myVlcControl.Play(new FileStream(@"..\..\..\Vlc.DotNet\Samples\Videos\BBB trailer.mov", FileMode.Open, FileAccess.Read));
         }
 
         private void OnButtonStopClicked(object sender, EventArgs e)

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Vlc.DotNet.Core.Interops.Signatures
+{
+    /// <summary>
+    /// Callback prototype to open a custom bitstream input media.
+    /// NoteL: The same media item can be opened multiple times. Each time, this callback is invoked. It should allocate and initialize any instance-specific resources, then store them in *datap. The instance resources can be freed in the libvlc_media_close_cb callback.
+    /// </summary>
+    /// <param name="opaque">private pointer as passed to CallbackOpenMediaDelegate()</param>
+    /// <param name="pData">storage space for a private data pointer [OUT]</param>
+    /// <param name="szData">byte length of the bitstream or UINT64_MAX if unknown [OUT]</param>
+    /// <returns>0 on success, non-zero on error. In case of failure, the other callbacks will not be invoked and any value stored in *datap and *sizep is discarded.</returns>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate Int32 CallbackOpenMediaDelegate(IntPtr opaque, out IntPtr pData, out UInt64 szData);
+    //typedef int(* libvlc_media_open_cb)(void* opaque, void** datap, uint64_t * sizep)
+
+    /// <summary>
+    /// Callback prototype to read data from a custom bitstream input media.
+    /// Note: If no data is immediately available, then the callback should sleep.
+    /// Warning: The application is responsible for avoiding deadlock situations. In particular, the callback should return an error if playback is stopped; if it does not return, then libvlc_media_player_stop() will never return.
+    /// </summary>
+    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="buf">start address of the buffer to read data into</param>
+    /// <param name="len">bytes length of the buffer</param>
+    /// <returns>strictly positive number of bytes read, 0 on end-of-stream, or -1 on non-recoverable error</returns>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, IntPtr buf, UIntPtr len);
+    //internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] buf, UIntPtr len);
+    //typedef ssize_t(* libvlc_media_read_cb)(void* opaque, unsigned char* buf, size_t len)
+
+    /// <summary>
+    /// Callback prototype to seek a custom bitstream input media.
+    /// </summary>
+    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="offset">absolute byte offset to seek to</param>
+    /// <returns>0 on success, -1 on error</returns>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate Int32 CallbackSeekMediaDelegate(IntPtr opaque, UInt64 offset);
+    //typedef int(* libvlc_media_seek_cb)(void* opaque, uint64_t offset)
+
+    /// <summary>
+    /// Callback prototype to close a custom bitstream input media.
+    /// </summary>
+    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void CallbackCloseMediaDelegate(IntPtr opaque);
+    //typedef void(* libvlc_media_close_cb)(void* opaque)
+
+    /// <summary>
+    /// Create a media with custom callbacks to read the data from.
+    /// Note: If open_cb is NULL, the opaque pointer will be passed to read_cb, seek_cb and close_cb, and the stream size will be treated as unknown.
+    /// The callbacks may be called asynchronously (from another thread). A single stream instance need not be reentrant. However the open_cb needs to be reentrant if the media is used by multiple player instances.
+    /// Warning: The callbacks may be used until all or any player instances that were supplied the media item are stopped.
+    /// </summary>
+    /// <returns>Return the newly created media or NULL on error.</returns>
+    [LibVlcFunction("libvlc_media_new_callbacks")]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate IntPtr CreateNewMediaFromCallbacks(IntPtr mediaPlayerInstance,
+        CallbackOpenMediaDelegate open_cb,
+        CallbackReadMediaDelegate read_cb,
+        CallbackSeekMediaDelegate seek_cb,
+        CallbackCloseMediaDelegate close_cb,
+        IntPtr opaque);
+}

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 2.0.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 2.0.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Signatures\libvlc.h\libvlc_get_changeset.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_tracks_info.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_stats.cs" />
+    <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_callbacks.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_track_info_t.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_stats_t.cs" />
     <Compile Include="Signatures\libvlc_media_player.h\libvlc_audio_get_delay.cs" />
@@ -172,6 +173,7 @@
     <Compile Include="VlcManager.CreateNewInstance.cs" />
     <Compile Include="VlcManager.CreateNewMediaFromLocation.cs" />
     <Compile Include="VlcManager.CreateNewMediaFromPath.cs" />
+    <Compile Include="VlcManager.CreateNewMediaFromStream.cs" />
     <Compile Include="VlcManager.DetachEvent.cs" />
     <Compile Include="VlcManager.GetAudioFilterList.cs" />
     <Compile Include="VlcManager.GetAudioTrack.cs" />

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 3.5.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 3.5.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_stats.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_tracks_info.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_is_parsed.cs" />
+    <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_callbacks.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_location.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_path.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_parse.cs" />
@@ -218,6 +219,7 @@
     <Compile Include="VlcManager.CreateNewInstance.cs" />
     <Compile Include="VlcManager.CreateNewMediaFromLocation.cs" />
     <Compile Include="VlcManager.CreateNewMediaFromPath.cs" />
+    <Compile Include="VlcManager.CreateNewMediaFromStream.cs" />
     <Compile Include="VlcManager.cs" />
     <Compile Include="VlcManager.DetachEvent.cs" />
     <Compile Include="VlcManager.Free.cs" />

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.0.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.0.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_stats.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_tracks_info.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_is_parsed.cs" />
+    <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_callbacks.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_location.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_path.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_parse.cs" />
@@ -206,6 +207,7 @@
     <Compile Include="Signatures\libvlc_media_player.h\libvlc_video_take_snapshot.cs" />
     <Compile Include="VlcEventManagerInstance.cs" />
     <Compile Include="VlcInstance.cs" />
+    <Compile Include="VlcManager.CreateNewMediaFromStream.cs" />
     <Compile Include="VlcManager.GetLength.cs" />
     <Compile Include="VlcManager.GetMediaPlayerVideoHostHandle.cs" />
     <Compile Include="VlcManager.GetTime.cs" />

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.5.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.5.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_stats.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_get_tracks_info.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_is_parsed.cs" />
+    <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_callbacks.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_location.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_new_path.cs" />
     <Compile Include="Signatures\libvlc_media.h\libvlc_media_parse.cs" />
@@ -223,6 +224,7 @@
     <Compile Include="VlcManager.CreateNewInstance.cs" />
     <Compile Include="VlcManager.CreateNewMediaFromLocation.cs" />
     <Compile Include="VlcManager.CreateNewMediaFromPath.cs" />
+    <Compile Include="VlcManager.CreateNewMediaFromStream.cs" />
     <Compile Include="VlcManager.cs" />
     <Compile Include="VlcManager.DetachEvent.cs" />
     <Compile Include="VlcManager.Free.cs" />

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -1,0 +1,163 @@
+﻿using System;
+#if !(NET20 || NET35)
+using System.Collections.Concurrent;
+#endif
+using System.Collections.Generic;
+using System.IO;
+using Vlc.DotNet.Core.Interops.Signatures;
+
+namespace Vlc.DotNet.Core.Interops
+{
+    public sealed partial class VlcManager
+    {
+        private static class StreamData
+        {
+            public static readonly CallbackOpenMediaDelegate CallbackOpenMediaDelegate = CallbackOpenMedia;
+            public static readonly CallbackReadMediaDelegate CallbackReadMediaDelegate = CallbackReadMedia;
+            public static readonly CallbackSeekMediaDelegate CallbackSeekMediaDelegate = CallbackSeekMedia;
+            public static readonly CallbackCloseMediaDelegate CallbackCloseMediaDelegate = CallbackCloseMedia;
+
+            private static int CallbackOpenMedia(IntPtr opaque, out IntPtr pData, out ulong szData)
+            {
+                pData = opaque;
+                try
+                {
+                    Stream stream = GetStream(opaque);
+                    szData = (ulong)stream.Length;
+                    stream.Seek(0L, SeekOrigin.Begin);
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    szData = 0UL;
+                    return -1;
+                }
+            }
+
+            private static IntPtr CallbackReadMedia(IntPtr opaque, IntPtr ipbuf, UIntPtr len)
+            {
+                try
+                {
+                    byte[] buf = new byte[(uint)len];
+                    Stream stream = GetStream(opaque);
+                    int read = stream.Read(buf, 0, (int)len);
+                    System.Runtime.InteropServices.Marshal.Copy(buf, 0, ipbuf, read);
+                    return new IntPtr(read);
+                }
+                catch (Exception ex)
+                {
+                    return new IntPtr(-1);
+                }
+            }
+            //private static IntPtr CallbackReadMedia(IntPtr opaque, byte[] buf, UIntPtr len)
+            //{
+            //    try
+            //    {
+            //        Stream stream = GetStream(opaque);
+            //        int read = stream.Read(buf, 0, (int)len);
+            //        return new IntPtr(read);
+            //    }
+            //    catch (Exception ex)
+            //    {
+            //        return new IntPtr(-1);
+            //    }
+            //}
+            private static Int32 CallbackSeekMedia(IntPtr opaque, UInt64 offset)
+            {
+                try
+                {
+                    Stream stream = GetStream(opaque);
+                    stream.Seek((long)offset, SeekOrigin.Begin);
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    return -1;
+                }
+            }
+            private static void CallbackCloseMedia(IntPtr opaque)
+            {
+                try
+                {
+                    RemoveStream(opaque);
+                }
+                catch (Exception ex)
+                {
+                }
+            }
+
+#if NET20 || NET35
+            private static readonly Dictionary<IntPtr, Stream> dicStreams = new Dictionary<IntPtr, Stream>();
+#else
+            private static readonly ConcurrentDictionary<IntPtr, Stream> dicStreams = new ConcurrentDictionary<IntPtr, Stream>();
+#endif
+
+            public static IntPtr AddStream(Stream stream)
+            {
+                IntPtr n = new IntPtr(1);
+                lock (dicStreams)
+                {
+                    for (; ;
+#if NET20 || NET35
+                        n = new IntPtr(n.ToInt64() + 1L)
+#else
+                        n = IntPtr.Add(n, 1)
+#endif
+                        )
+                    {
+                        if (n == IntPtr.Zero)
+                            return IntPtr.Zero;
+                        if (!dicStreams.ContainsKey(n))
+                            break;
+                    }
+                    dicStreams[n] = stream;
+                }
+                return n;
+            }
+            public static Stream GetStream(IntPtr n)
+            {
+#if NET20 || NET35
+                lock (dicStreams)
+                {
+                    if (!dicStreams.ContainsKey(n))
+                        return null;
+                    return dicStreams[n];
+                }
+#else
+                Stream result;
+                if (!dicStreams.TryGetValue(n, out result))
+                    return null;
+                return result;
+#endif
+            }
+            public static void RemoveStream(IntPtr n)
+            {
+#if NET20 || NET35
+                lock (dicStreams)
+                {
+                    if (dicStreams.ContainsKey(n))
+                        dicStreams.Remove(n);
+                }
+#else
+                Stream result;
+                dicStreams.TryRemove(n, out result);
+#endif
+            }
+        }
+        public VlcMediaInstance CreateNewMediaFromStream(Stream stream)
+        {
+            IntPtr opaque = StreamData.AddStream(stream);
+            if (opaque == IntPtr.Zero)
+                return null;
+            var result = VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromCallbacks>().Invoke(
+                myVlcInstance,
+                StreamData.CallbackOpenMediaDelegate,
+                StreamData.CallbackReadMediaDelegate,
+                StreamData.CallbackSeekMediaDelegate,
+                StreamData.CallbackCloseMediaDelegate,
+                opaque
+                ));
+            return result;
+        }
+    }
+}

--- a/src/Vlc.DotNet.Core/VlcMedia/VlcMedia.cs
+++ b/src/Vlc.DotNet.Core/VlcMedia/VlcMedia.cs
@@ -44,6 +44,15 @@ namespace Vlc.DotNet.Core
         {
         }
 
+        internal VlcMedia(VlcMediaPlayer player, Stream stream, params string[] options)
+#if NET20
+            : this(player, VlcMediaInstanceExtensions.AddOptionToMedia(player.Manager.CreateNewMediaFromStream(stream), player.Manager, options))
+#else
+            : this(player, player.Manager.CreateNewMediaFromStream(stream).AddOptionToMedia(player.Manager, options))
+#endif
+        {
+        }
+
         internal VlcMedia(VlcMediaPlayer player, VlcMediaInstance mediaInstance)
         {
             if(!LoadedMedias.ContainsKey(player))

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -151,6 +151,11 @@ namespace Vlc.DotNet.Core
             return SetMedia(new VlcMedia(this, mrl, options));
         }
 
+        public VlcMedia SetMedia(Stream stream, params string[] options)
+        {
+            return SetMedia(new VlcMedia(this, stream, options));
+        }
+
         private VlcMedia SetMedia(VlcMedia media)
         {
             var currentMedia = GetMedia();

--- a/src/Vlc.DotNet.Forms/VlcControl.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.cs
@@ -166,6 +166,16 @@ namespace Vlc.DotNet.Forms
             }
         }
 
+        public void Play(Stream stream, params string[] options)
+        {
+            //EndInit();
+            if (myVlcMediaPlayer != null)
+            {
+                myVlcMediaPlayer.SetMedia(stream, options);
+                Play();
+            }
+        }
+
         public void Pause()
         {
             //EndInit();
@@ -411,6 +421,12 @@ namespace Vlc.DotNet.Forms
         {
             //EndInit();
             myVlcMediaPlayer.SetMedia(mrl, options);
+        }
+
+        public void SetMedia(Stream stream, params string[] options)
+        {
+            //EndInit();
+            myVlcMediaPlayer.SetMedia(stream, options);
         }
         #endregion
     }


### PR DESCRIPTION
Added an ability to play a IO.Stream. Useful to implement impersonation or blob player.
Uses libvlc_media_new_callbacks call that available only in vlc-3.0.0-git version, not prebuilt vlc releases