### PR TITLE
Fixed AnyCPU samples projects running on x64 host that won't load the DLLs from the correct folder

### DIFF
--- a/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
+++ b/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
@@ -18,7 +18,7 @@ namespace Vlc.DotNet.Forms.Samples
             var currentDirectory = new FileInfo(currentAssembly.Location).DirectoryName;
             if (currentDirectory == null)
                 return;
-            if (AssemblyName.GetAssemblyName(currentAssembly.Location).ProcessorArchitecture == ProcessorArchitecture.X86)
+            if (IntPtr.Size == 4)
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x86\"));
             else
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x64\"));

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
@@ -23,7 +23,7 @@ namespace Vlc.DotNet.Wpf.Samples
             var currentDirectory = new FileInfo(currentAssembly.Location).DirectoryName;
             if (currentDirectory == null)
                 return;
-            if (AssemblyName.GetAssemblyName(currentAssembly.Location).ProcessorArchitecture == ProcessorArchitecture.X86)
+            if (IntPtr.Size == 4)
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x86\"));
             else
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x64\"));


### PR DESCRIPTION
fixed Samples by choosing the libraries to load based on IntPtr.Size rather than on the host OS CPU architecture