### PR TITLE
Added the ability to get VLC log messages from the application

### DIFF
--- a/src/Samples/Vlc.DotNet.Forms.Samples/Sample.Designer.cs
+++ b/src/Samples/Vlc.DotNet.Forms.Samples/Sample.Designer.cs
@@ -45,27 +45,30 @@
             this.myLblVideoWidth = new System.Windows.Forms.Label();
             this.myLblVideoCodec = new System.Windows.Forms.Label();
             this.myLblVideoHeight = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.myVlcControl)).BeginInit();
             this.myCbxAspectRatio = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.myVlcControl)).BeginInit();
             this.myGrpAudioInformations.SuspendLayout();
             this.myGrpVideoInformations.SuspendLayout();
             this.SuspendLayout();
             // 
             // myVlcControl
             // 
-            this.myVlcControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.myVlcControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.myVlcControl.BackColor = System.Drawing.SystemColors.ButtonShadow;
             this.myVlcControl.Location = new System.Drawing.Point(12, 12);
             this.myVlcControl.Name = "myVlcControl";
             this.myVlcControl.Size = new System.Drawing.Size(564, 338);
+            this.myVlcControl.Spu = -1;
             this.myVlcControl.TabIndex = 0;
             this.myVlcControl.Text = "vlcRincewindControl1";
             this.myVlcControl.VlcLibDirectory = null;
+            this.myVlcControl.VlcMediaplayerOptions = null;
             this.myVlcControl.VlcLibDirectoryNeeded += new System.EventHandler<Vlc.DotNet.Forms.VlcLibDirectoryNeededEventArgs>(this.OnVlcControlNeedLibDirectory);
             this.myVlcControl.LengthChanged += new System.EventHandler<Vlc.DotNet.Core.VlcMediaPlayerLengthChangedEventArgs>(this.OnVlcMediaLengthChanged);
+            this.myVlcControl.Log += new System.EventHandler<Vlc.DotNet.Core.VlcMediaPlayerLogEventArgs>(this.OnVlcMediaPlayerLog);
             this.myVlcControl.Paused += new System.EventHandler<Vlc.DotNet.Core.VlcMediaPlayerPausedEventArgs>(this.OnVlcPaused);
             this.myVlcControl.Playing += new System.EventHandler<Vlc.DotNet.Core.VlcMediaPlayerPlayingEventArgs>(this.OnVlcPlaying);
             this.myVlcControl.PositionChanged += new System.EventHandler<Vlc.DotNet.Core.VlcMediaPlayerPositionChangedEventArgs>(this.OnVlcPositionChanged);
@@ -244,7 +247,7 @@
             "4:3"});
             this.myCbxAspectRatio.Location = new System.Drawing.Point(680, 170);
             this.myCbxAspectRatio.Name = "myCbxAspectRatio";
-            this.myCbxAspectRatio.Size = new System.Drawing.Size(121, 20);
+            this.myCbxAspectRatio.Size = new System.Drawing.Size(121, 21);
             this.myCbxAspectRatio.TabIndex = 11;
             this.myCbxAspectRatio.TextChanged += new System.EventHandler(this.myCbxAspectRatio_TextChanged);
             // 
@@ -254,7 +257,7 @@
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(580, 173);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(98, 12);
+            this.label3.Size = new System.Drawing.Size(101, 13);
             this.label3.TabIndex = 12;
             this.label3.Text = "Video Aspect Ratio:";
             // 
@@ -278,8 +281,8 @@
             this.Controls.Add(this.myVlcControl);
             this.Name = "Sample";
             this.Text = "Vlc.DotNet - Winform Player Sample";
-            ((System.ComponentModel.ISupportInitialize)(this.myVlcControl)).EndInit();
             this.SizeChanged += new System.EventHandler(this.Sample_SizeChanged);
+            ((System.ComponentModel.ISupportInitialize)(this.myVlcControl)).EndInit();
             this.myGrpAudioInformations.ResumeLayout(false);
             this.myGrpAudioInformations.PerformLayout();
             this.myGrpVideoInformations.ResumeLayout(false);

--- a/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
+++ b/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
@@ -5,6 +5,8 @@ using System.Windows.Forms;
 
 namespace Vlc.DotNet.Forms.Samples
 {
+    using System.Diagnostics;
+
     public partial class Sample : Form
     {
         public Sample()
@@ -202,5 +204,9 @@ namespace Vlc.DotNet.Forms.Samples
             }
         }
 
+        private void OnVlcMediaPlayerLog(object sender, Core.VlcMediaPlayerLogEventArgs e)
+        {
+            Debug.WriteLine("libVlc : {0} {1}", e.Level, e.Message);
+        }
     }
 }

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
@@ -15,6 +15,12 @@ namespace Vlc.DotNet.Wpf.Samples
             InitializeComponent();
             myControl.MediaPlayer.VlcLibDirectoryNeeded += OnVlcControlNeedsLibDirectory;
             myControl.MediaPlayer.EndInit();
+
+            // This can also be called before EndInit
+            this.myControl.MediaPlayer.Log += (sender, args) =>
+            {
+                System.Diagnostics.Debug.WriteLine("libVlc : {0} {1}", args.Level, args.Message);
+            };
         }
 
         private void OnVlcControlNeedsLibDirectory(object sender, Forms.VlcLibDirectoryNeededEventArgs e)

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_log_cb.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_log_cb.cs
@@ -1,0 +1,12 @@
+﻿namespace Vlc.DotNet.Core.Interops.Signatures
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// The delegate type that represent logging functions
+    /// </summary>
+    [LibVlcFunction("libvlc_log_cb")]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void LogCallback(IntPtr data, VlcLogLevel level, IntPtr ctx, [MarshalAs(UnmanagedType.LPStr)] string format, IntPtr args);
+}

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_log_level_e.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_log_level_e.cs
@@ -1,0 +1,11 @@
+﻿namespace Vlc.DotNet.Core.Interops.Signatures
+{
+    public enum VlcLogLevel
+      : int
+    {
+        Debug = 0,
+        Notice = 2,
+        Warning = 3,
+        Error = 4
+    }
+}

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_log_set.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_log_set.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Vlc.DotNet.Core.Interops.Signatures
+{
+    /// <summary>
+    /// Registers a log callback
+    /// </summary>
+    /// <param name="libVlcInstance">The libvlc instance.</param>
+    /// <param name="callback">The method that will be called whenever a log is available.</param>
+    /// <param name="userData">User provided data to carry with the event.</param>
+    [LibVlcFunction("libvlc_log_set")]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void SetLog(IntPtr libVlcInstance, LogCallback callback, IntPtr userData);
+}

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 2.0.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 2.0.csproj
@@ -51,8 +51,11 @@
     <Compile Include="LibVlcFunctionAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Signatures\InteropObjectInstance.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_level_e.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_set.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_video_filter_list_get.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_audio_filter_list_get.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_cb.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_list_release.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_t.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_changeset.cs" />
@@ -210,6 +213,7 @@
     <Compile Include="VlcManager.NextFrame.cs" />
     <Compile Include="VlcManager.SetRate.cs" />
     <Compile Include="VlcManager.GetRate.cs" />
+    <Compile Include="VlcManager.SetLog.cs" />
     <Compile Include="VlcManager.GetMediaPosition.cs" />
     <Compile Include="VlcManager.GetMediaChapter.cs" />
     <Compile Include="VlcManager.GetMediaChapterCount.cs" />
@@ -306,7 +310,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 3.5.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 2 - .Net 3.5.csproj
@@ -63,6 +63,9 @@
     <Compile Include="Signatures\libvlc.h\libvlc_get_changeset.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_compiler.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_version.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_cb.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_level_e.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_set.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_list_release.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_t.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_new.cs" />
@@ -270,6 +273,7 @@
     <Compile Include="VlcManager.SetAudioOutput.cs" />
     <Compile Include="VlcManager.SetAudioOutputDevice.cs" />
     <Compile Include="VlcManager.SetAudioTrack.cs" />
+    <Compile Include="VlcManager.SetLog.cs" />
     <Compile Include="VlcManager.SetMediaChapter.cs" />
     <Compile Include="VlcManager.SetMediaMeta.cs" />
     <Compile Include="VlcManager.SetMediaPlayerVideoHostHandle.cs" />
@@ -307,7 +311,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.0.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.0.csproj
@@ -63,6 +63,9 @@
     <Compile Include="Signatures\libvlc.h\libvlc_get_changeset.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_compiler.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_version.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_cb.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_level_e.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_set.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_list_release.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_t.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_new.cs" />
@@ -277,6 +280,7 @@
     <Compile Include="VlcManager.SetAudioOutput.cs" />
     <Compile Include="VlcManager.SetAudioOutputDevice.cs" />
     <Compile Include="VlcManager.SetAudioTrack.cs" />
+    <Compile Include="VlcManager.SetLog.cs" />
     <Compile Include="VlcManager.SetMediaChapter.cs" />
     <Compile Include="VlcManager.SetMediaMeta.cs" />
     <Compile Include="VlcManager.SetMediaPlayerVideoHostHandle.cs" />
@@ -307,7 +311,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.5.csproj
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops - CLR 4 - .Net 4.5.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Signatures\InteropObjectInstance.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_audio_filter_list_get.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_cb.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_callback_t.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_clearerr.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_errmsg.cs" />
@@ -68,6 +69,8 @@
     <Compile Include="Signatures\libvlc.h\libvlc_get_changeset.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_compiler.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_get_version.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_level_e.cs" />
+    <Compile Include="Signatures\libvlc.h\libvlc_log_set.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_list_release.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_module_description_t.cs" />
     <Compile Include="Signatures\libvlc.h\libvlc_new.cs" />
@@ -275,6 +278,7 @@
     <Compile Include="VlcManager.SetAudioOutput.cs" />
     <Compile Include="VlcManager.SetAudioOutputDevice.cs" />
     <Compile Include="VlcManager.SetAudioTrack.cs" />
+    <Compile Include="VlcManager.SetLog.cs" />
     <Compile Include="VlcManager.SetMediaChapter.cs" />
     <Compile Include="VlcManager.SetMediaMeta.cs" />
     <Compile Include="VlcManager.SetMediaPlayerVideoHostHandle.cs" />
@@ -307,7 +311,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetLog.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetLog.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Vlc.DotNet.Core.Interops.Signatures;
+
+namespace Vlc.DotNet.Core.Interops
+{
+    public sealed partial class VlcManager
+    {
+        /// <summary>
+        /// Keeps a reference to the last callback that was given to the <see cref="SetLog"/> method.
+        /// This is to avoid garbage collection of the delegate before the function is called.
+        /// </summary>
+        private LogCallback _logCallbackReference;
+
+        public void SetLog(LogCallback callback)
+        {
+            if (callback == null)
+                throw new ArgumentException("Callback for log is not initialized.");
+            this._logCallbackReference = callback;
+            GetInteropDelegate<SetLog>().Invoke(this.myVlcInstance, this._logCallbackReference, IntPtr.Zero);
+        }
+    }
+}

--- a/src/Vlc.DotNet.Core.Interops/Win32Interops.cs
+++ b/src/Vlc.DotNet.Core.Interops/Win32Interops.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 
 namespace Vlc.DotNet.Core.Interops
 {
+    using System.Text;
+
     internal static class Win32Interops
     {
         /// <summary>
@@ -46,6 +48,33 @@ namespace Vlc.DotNet.Core.Interops
         /// <returns>If the function succeeds, the return value is a handle to the previous parent window. If the function fails, the return value is NULL. To get extended error information, call GetLastError.</returns>
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
+
+        /// <summary>
+        /// Format a string using printf style markers
+        /// </summary>
+        /// <remarks>
+        /// See https://stackoverflow.com/a/37629480/2663813
+        /// </remarks>
+        /// <param name="buffer">The output buffer (should be large enough, use _vscprintf)</param>
+        /// <param name="format">The message format</param>
+        /// <param name="args">The variable arguments list pointer. We do not know what it is, but the pointer must be given as-is from C back to sprintf.</param>
+        /// <returns>A negative value on failure, the number of characters written otherwise.</returns>
+        [DllImport("msvcrt.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int vsprintf(
+            StringBuilder buffer,
+            string format,
+            IntPtr args);
+
+        /// <summary>
+        /// Compute the size required by vsprintf to print the parameters.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <param name="ptr"></param>
+        /// <returns></returns>
+        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int _vscprintf(
+            string format,
+            IntPtr ptr);
 
     }
 }

--- a/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 2 - .Net 2.0.csproj
+++ b/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 2 - .Net 2.0.csproj
@@ -86,6 +86,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.ScrambledChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.SeekableChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.SnapshotTaken.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Log.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Stopped.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.TimeChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.TitleChanged.cs" />
@@ -97,6 +98,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerForwardEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerLengthChangedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerMediaChangedEventArgs.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayerLogEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerOpeningEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerPausableChangedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerPausedEventArgs.cs" />

--- a/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 2 - .Net 3.5.csproj
+++ b/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 2 - .Net 3.5.csproj
@@ -78,6 +78,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.EndReached.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Forward.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.LengthChanged.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Log.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.MediaChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Opening.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.PausableChanged.cs" />
@@ -97,6 +98,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerEndReachedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerForwardEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerLengthChangedEventArgs.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayerLogEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerMediaChangedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerOpeningEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerPausableChangedEventArgs.cs" />
@@ -140,7 +142,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 4 - .Net 4.0.csproj
+++ b/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 4 - .Net 4.0.csproj
@@ -79,6 +79,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Forward.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.LengthChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.MediaChanged.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Log.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Opening.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.PausableChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Paused.cs" />
@@ -97,6 +98,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerEndReachedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerForwardEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerLengthChangedEventArgs.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayerLogEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerMediaChangedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerOpeningEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerPausableChangedEventArgs.cs" />
@@ -139,7 +141,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 4 - .Net 4.5.csproj
+++ b/src/Vlc.DotNet.Core/Vlc.DotNet.Core - CLR 4 - .Net 4.5.csproj
@@ -78,6 +78,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.EndReached.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Forward.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.LengthChanged.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Log.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.MediaChanged.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.Opening.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayer.Events.PausableChanged.cs" />
@@ -97,6 +98,7 @@
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerEndReachedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerForwardEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerLengthChangedEventArgs.cs" />
+    <Compile Include="VlcMediaPlayer\VlcMediaPlayerLogEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerMediaChangedEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerOpeningEventArgs.cs" />
     <Compile Include="VlcMediaPlayer\VlcMediaPlayerPausableChangedEventArgs.cs" />

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Vlc.DotNet.Core.Interops.Signatures;
+
+namespace Vlc.DotNet.Core
+{
+    using System.Text;
+    using Vlc.DotNet.Core.Interops;
+
+    public sealed partial class VlcMediaPlayer
+    {
+        private object _logLock = new object();
+
+        /// <summary>
+        /// The real log event handlers.
+        /// </summary>
+        private EventHandler<VlcMediaPlayerLogEventArgs> _log;
+
+        /// <summary>
+        /// A boolean to make sure that we are calling SetLog only once
+        /// </summary>
+        private bool _logAttached = false;
+
+        /// <summary>
+        /// The event that is triggered when a log is emitted from libVLC.
+        /// Listening to this event will discard the default logger in libvlc.
+        /// </summary>
+        public event EventHandler<VlcMediaPlayerLogEventArgs> Log
+        {
+            add
+            {
+                lock (this._logLock)
+                {
+                    if (!this._logAttached)
+                    {
+                        this.Manager.SetLog(this.OnLogInternal);
+                        this._logAttached = true;
+                    }
+                    this._log += value;
+                }
+            }
+
+            remove
+            {
+                lock (this._logLock)
+                {
+                    this._log -= value;
+                }
+            }
+        }
+
+        private void OnLogInternal(IntPtr data, VlcLogLevel level, IntPtr ctx, string format, IntPtr args)
+        {
+            if (this._log != null)
+            {
+                // Original source: https://stackoverflow.com/a/37629480/2663813
+                var sb = new StringBuilder(Win32Interops._vscprintf(format, args) + 1);
+                Win32Interops.vsprintf(sb, format, args);
+
+                var formattedMessage = sb.ToString();
+
+                this._log(this.myMediaPlayerInstance, new VlcMediaPlayerLogEventArgs(level, formattedMessage));
+            }
+        }
+    }
+}

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLogEventArgs.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLogEventArgs.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Vlc.DotNet.Core
+{
+    using Vlc.DotNet.Core.Interops.Signatures;
+
+    public sealed class VlcMediaPlayerLogEventArgs : EventArgs
+    {
+        public VlcMediaPlayerLogEventArgs(VlcLogLevel level, string message)
+        {
+            this.Level = level;
+            this.Message = message;
+        }
+
+        /// <summary>
+        /// The severity of the log message.
+        /// By default, you will only get error messages, but you can get all messages by specifying "-vv" in the options.
+        /// </summary>
+        public VlcLogLevel Level { get; }
+
+        /// <summary>
+        /// The log message
+        /// </summary>
+        public string Message { get; }
+    }
+}

--- a/src/Vlc.DotNet.Forms/VlcControl.Events.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.Events.cs
@@ -174,6 +174,51 @@ namespace Vlc.DotNet.Forms
         }
         #endregion
 
+        #region Log event
+        private object _logLocker = new object();
+
+        private EventHandler<VlcMediaPlayerLogEventArgs> _log;
+
+        private void OnLogInternal(object sender, VlcMediaPlayerLogEventArgs args)
+        {
+            lock(this._logLocker)
+            {
+                if (this._log != null)
+                {
+                    this._log(sender, args);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The event that is triggered when a log is emitted from libVLC.
+        /// Listening to this event will discard the default logger in libvlc.
+        /// </summary>
+        [Category("Media Player")]
+        public event EventHandler<VlcMediaPlayerLogEventArgs> Log
+        {
+            add
+            {
+                lock (this._logLocker)
+                {
+                    this._log += value;
+                }
+                if (this.myVlcMediaPlayer != null)
+                {
+                    // Registers if not already done.
+                    this.RegisterLogging();
+                }
+            }
+            remove
+            {
+                lock (this._logLocker)
+                {
+                    this._log -= value;
+                }
+            }
+        }
+        #endregion
+
         #region Media Changed event
         private void OnMediaChangedInternal(object sender, VlcMediaPlayerMediaChangedEventArgs e)
         {

--- a/src/Vlc.DotNet.Forms/VlcControl.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.cs
@@ -72,8 +72,27 @@ namespace Vlc.DotNet.Forms
             {
                 myVlcMediaPlayer = new VlcMediaPlayer(VlcLibDirectory, VlcMediaplayerOptions);
             }
+
+            if (this._log != null)
+            {
+                this.RegisterLogging();
+            }
             myVlcMediaPlayer.VideoHostControlHandle = Handle;
+
             RegisterEvents();
+        }
+
+        private bool _loggingRegistered = false;
+
+        /// <summary>
+        /// Connects (only the first time) the events from <see cref="myVlcMediaPlayer"/> to the event handlers registered on this instance
+        /// </summary>
+        private void RegisterLogging()
+        {
+            if (this._loggingRegistered)
+                return;
+            this.myVlcMediaPlayer.Log += this.OnLogInternal;
+            this._loggingRegistered = true;
         }
 
         // work around http://stackoverflow.com/questions/34664/designmode-with-controls/708594


### PR DESCRIPTION
Added the ability to hook a .net event handler to libvlc.

It has the limitation of libvlc, i.e. it does not offer the ability to get logs from the very beginning of the libvlc instanciation.

What has changed for the library users:
- New `Log` event has been created
- If `Log` is not used, the behavior is left unchanged
- If the `Log` event is listened, before or after EndInit (both cases are handled), the libvlc logger (that writes the vlc-log.txt file) is stopped and all logs are transferred to the application. If you remove the `Log` event handler, the previous logger is *not* restored

Things to be discussed before merging:

- [ ] Do we need to get more info than just the message string? i.e. do we need to replicate the `vlc_log_t` structure and expose it in the EventArgs ? [vlc_log_t](https://github.com/videolan/vlc/blob/694399e23000232708b2d514a6a265cfc023ddde/include/vlc_messages.h#L55)
- [ ] Look at why the libvlc version does not appear in the log (it should)

