### PR TITLE
Logging fix

### DIFF
--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
@@ -5,6 +5,7 @@ namespace Vlc.DotNet.Core
 {
     using System.Runtime.InteropServices;
     using System.Text;
+    using System.Threading;
     using Vlc.DotNet.Core.Interops;
 
     public sealed partial class VlcMediaPlayer
@@ -76,7 +77,11 @@ namespace Vlc.DotNet.Core
                 uint? line;
                 this.Manager.GetLogContext(ctx, out module, out file, out line);
 
-                this._log(this.myMediaPlayerInstance, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line));
+                // Do the notification on another thread, so that VLC is not interrupted by the logging
+                ThreadPool.QueueUserWorkItem(eventArgs =>
+                {
+                    this._log(this.myMediaPlayerInstance, (VlcMediaPlayerLogEventArgs)eventArgs);
+                }, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line));
             }
         }
     }

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLogEventArgs.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLogEventArgs.cs
@@ -32,12 +32,14 @@ namespace Vlc.DotNet.Core
         public string Module { get; }
 
         /// <summary>
-        /// The source file that emitted the message
+        /// The source file that emitted the message.
+        /// This may be <see langword="null"/> if that info is not available, i.e. always if you are using a release version of VLC.
         /// </summary>
         public string SourceFile { get; }
 
         /// <summary>
         /// The line in the <see cref="SourceFile"/> at which the message was emitted.
+        /// This may be <see langword="null"/> if that info is not available, i.e. always if you are using a release version of VLC.
         /// </summary>
         public uint? SourceLine { get; }
     }


### PR DESCRIPTION
Fixed an issue where the vlc was blocked because of the user's logging method taking too much time before returning.

Solution : launch the event from another thread from the `ThreadPool`