### PR TITLE
Fixed #74 by adding support for UTF-8 in options

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_new.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc.h/libvlc_new.cs
@@ -9,5 +9,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <returns>Return the libvlc instance or NULL in case of error.</returns>
     [LibVlcFunction("libvlc_new")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr CreateNewInstance(int argc, string[] argv);
+    internal delegate IntPtr CreateNewInstance(int argc, IntPtr[] argv);
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.AddOptionToMedia.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.AddOptionToMedia.cs
@@ -13,7 +13,7 @@ namespace Vlc.DotNet.Core.Interops
                 throw new ArgumentException("Media instance is not initialized.");
             if (string.IsNullOrEmpty(option))
                 return;
-            var handle = GCHandle.Alloc(Encoding.ASCII.GetBytes(option), GCHandleType.Pinned);
+            var handle = GCHandle.Alloc(Encoding.UTF8.GetBytes(option), GCHandleType.Pinned);
             GetInteropDelegate<AddOptionToMedia>().Invoke(mediaInstance, handle.AddrOfPinnedObject());
             handle.Free();
         }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewInstance.cs
@@ -1,14 +1,35 @@
-﻿using Vlc.DotNet.Core.Interops.Signatures;
-
-namespace Vlc.DotNet.Core.Interops
+﻿namespace Vlc.DotNet.Core.Interops
 {
+    using System;
+    using System.Runtime.InteropServices;
+    using Vlc.DotNet.Core.Interops.Signatures;
+    using System.Text;
+
     public sealed partial class VlcManager
     {
         public void CreateNewInstance(string[] args)
         {
-            if (args == null)
-                args = new string[0];
-            myVlcInstance = new VlcInstance(this, GetInteropDelegate<CreateNewInstance>().Invoke(args.Length, args));
+            IntPtr[] utf8Args = new IntPtr[args?.Length ?? 0];
+            try
+            {
+                for (var i = 0; i < utf8Args.Length; i++)
+                {
+                    byte[] bytes = Encoding.UTF8.GetBytes(args[i]);
+                    var buffer = Marshal.AllocHGlobal(bytes.Length + 1);
+                    Marshal.Copy(bytes, 0, buffer, bytes.Length);
+                    Marshal.WriteByte(buffer, bytes.Length, 0);
+                    utf8Args[i] = buffer;
+                }
+
+                myVlcInstance = new VlcInstance(this, GetInteropDelegate<CreateNewInstance>().Invoke(utf8Args.Length, utf8Args));
+            }
+            finally
+            {
+                foreach (var arg in utf8Args)
+                {
+                    Marshal.FreeHGlobal(arg);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Added support for UTF-8 in options, which fixes #74.
You can now put special characters in marquee! Example (vlc 3.0 only for emoji support)

```
myControl.MediaPlayer.VlcMediaplayerOptions = new[] { "--sub-source=marq{marquee=testç 👍,color=16776960}" };
```