### PR TITLE
Fix NuGet package format

### DIFF
--- a/nuget/Vlc.DotNet.Core.Interops.nuspec
+++ b/nuget/Vlc.DotNet.Core.Interops.nuspec
@@ -12,9 +12,9 @@
         <tags>vlc media wrapper interop interops</tags>
     </metadata>
     <files>
-        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 2.0\Vlc.DotNet.Core.Interops.dll" target="lib\net20\AnyCPU\Vlc.DotNet.Core.Interops.dll" />
-        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Core.Interops.dll" target="lib\net35\AnyCPU\Vlc.DotNet.Core.Interops.dll" />
-        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Core.Interops.dll" target="lib\net40\AnyCPU\Vlc.DotNet.Core.Interops.dll" />
-        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Core.Interops.dll" target="lib\net45\AnyCPU\Vlc.DotNet.Core.Interops.dll" />
+        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 2.0\Vlc.DotNet.Core.Interops.dll" target="lib\net20\Vlc.DotNet.Core.Interops.dll" />
+        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Core.Interops.dll" target="lib\net35\Vlc.DotNet.Core.Interops.dll" />
+        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Core.Interops.dll" target="lib\net40\Vlc.DotNet.Core.Interops.dll" />
+        <file src="..\build\Vlc.DotNet.Core.Interops\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Core.Interops.dll" target="lib\net45\Vlc.DotNet.Core.Interops.dll" />
     </files>
 </package>

--- a/nuget/Vlc.DotNet.Core.nuspec
+++ b/nuget/Vlc.DotNet.Core.nuspec
@@ -18,9 +18,9 @@
         </frameworkAssemblies>
     </metadata>
     <files>
-        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 2.0\Vlc.DotNet.Core.dll" target="lib\net20\AnyCPU\Vlc.DotNet.Core.dll" />
-        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Core.dll" target="lib\net35\AnyCPU\Vlc.DotNet.Core.dll" />
-        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Core.dll" target="lib\net40\AnyCPU\Vlc.DotNet.Core.dll" />
-        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Core.dll" target="lib\net45\AnyCPU\Vlc.DotNet.Core.dll" />
+        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 2.0\Vlc.DotNet.Core.dll" target="lib\net20\Vlc.DotNet.Core.dll" />
+        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Core.dll" target="lib\net35\Vlc.DotNet.Core.dll" />
+        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Core.dll" target="lib\net40\Vlc.DotNet.Core.dll" />
+        <file src="..\build\Vlc.DotNet.Core\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Core.dll" target="lib\net45\Vlc.DotNet.Core.dll" />
     </files>
 </package>

--- a/nuget/Vlc.DotNet.Forms.nuspec
+++ b/nuget/Vlc.DotNet.Forms.nuspec
@@ -21,9 +21,9 @@
         </frameworkAssemblies>
     </metadata>
     <files>
-        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 2.0\Vlc.DotNet.Forms.dll" target="lib\net20\AnyCPU\Vlc.DotNet.Forms.dll" />
-        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Forms.dll" target="lib\net35\AnyCPU\Vlc.DotNet.Forms.dll" />
-        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Forms.dll" target="lib\net40\AnyCPU\Vlc.DotNet.Forms.dll" />
-        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Forms.dll" target="lib\net45\AnyCPU\Vlc.DotNet.Forms.dll" />
+        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 2.0\Vlc.DotNet.Forms.dll" target="lib\net20\Vlc.DotNet.Forms.dll" />
+        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Forms.dll" target="lib\net35\Vlc.DotNet.Forms.dll" />
+        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Forms.dll" target="lib\net40\Vlc.DotNet.Forms.dll" />
+        <file src="..\build\Vlc.DotNet.Forms\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Forms.dll" target="lib\net45\Vlc.DotNet.Forms.dll" />
     </files>
 </package>

--- a/nuget/Vlc.DotNet.Wpf.nuspec
+++ b/nuget/Vlc.DotNet.Wpf.nuspec
@@ -22,8 +22,8 @@
        </frameworkAssemblies>
     </metadata>
     <files>
-        <file src="..\build\Vlc.DotNet.Wpf\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Wpf.dll" target="lib\net35\AnyCPU\Vlc.DotNet.Wpf.dll" />
-        <file src="..\build\Vlc.DotNet.Wpf\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Wpf.dll" target="lib\net40\AnyCPU\Vlc.DotNet.Wpf.dll" />
-        <file src="..\build\Vlc.DotNet.Wpf\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Wpf.dll" target="lib\net45\AnyCPU\Vlc.DotNet.Wpf.dll" />
+        <file src="..\build\Vlc.DotNet.Wpf\Release - AnyCPU - .Net 3.5\Vlc.DotNet.Wpf.dll" target="lib\net35\Vlc.DotNet.Wpf.dll" />
+        <file src="..\build\Vlc.DotNet.Wpf\Release - AnyCPU - .Net 4.0\Vlc.DotNet.Wpf.dll" target="lib\net40\Vlc.DotNet.Wpf.dll" />
+        <file src="..\build\Vlc.DotNet.Wpf\Release - AnyCPU - .Net 4.5\Vlc.DotNet.Wpf.dll" target="lib\net45\Vlc.DotNet.Wpf.dll" />
     </files>
 </package>


### PR DESCRIPTION
#308 will make this fix obsolete.

The NuGet packages produced by Vlc.DotNet are invalid. The assemblies are located in `lib\{TFM}\AnyCPU\`, but the NuGet specifications do not allow for an `AnyCPU` subfolder. Instead, the libraries should just go in `lib\{TFM}`.

I hit this on Visual Studio 2017; perhaps newer NuGet versions are a bit more strict about the folder structure.

This PR fixes that.

Fixes #276
Obsoletes #300
Fixes NuGet/Home#4417
Fixes NuGet/Home#4259
Fixes NuGet/Home#5678