### PR TITLE
Convert an null reference to VlcInstance to IntPtr.Zero

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/VlcInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcInstance.cs
@@ -21,6 +21,9 @@ namespace Vlc.DotNet.Core.Interops
 
         public static implicit operator IntPtr(VlcInstance instance)
         {
+            if (instance == null)
+                return IntPtr.Zero;
+
             return instance.Pointer;
         }
     }


### PR DESCRIPTION
Right now this would throw a `NullReferenceException` when `instance` is null.

`IntPtr.Zero` is the unmanaged equivalent of `null`. 