### PR TITLE
Validate myVlcInstance before passing it to unmanaged code.

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateMediaPlayer.cs
@@ -7,6 +7,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public VlcMediaPlayerInstance CreateMediaPlayer()
         {
+            EnsureVlcInstance();
+
             return new VlcMediaPlayerInstance(this, GetInteropDelegate<CreateMediaPlayer>().Invoke(myVlcInstance));
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromLocation.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromLocation.cs
@@ -8,6 +8,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public VlcMediaInstance CreateNewMediaFromLocation(string mrl)
         {
+            EnsureVlcInstance();
+
             using (var handle = Utf8InteropStringConverter.ToUtf8Interop(mrl))
             {
                 return VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromLocation>().Invoke(myVlcInstance, handle.DangerousGetHandle()));

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromPath.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromPath.cs
@@ -8,6 +8,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public VlcMediaInstance CreateNewMediaFromPath(string mrl)
         {
+            EnsureVlcInstance();
+
             using (var handle = Utf8InteropStringConverter.ToUtf8Interop(mrl))
             {
                 return VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromPath>().Invoke(myVlcInstance, handle.DangerousGetHandle()));

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioFilterList.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioFilterList.cs
@@ -7,6 +7,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public IntPtr GetAudioFilterList()
         {
+            EnsureVlcInstance();
+
             return GetInteropDelegate<GetAudioFilterList>().Invoke(myVlcInstance);
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceCount.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceCount.cs
@@ -7,6 +7,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public int GetAudioOutputDeviceCount(string outputName)
         {
+            EnsureVlcInstance();
+
             return GetInteropDelegate<GetAudioOutputDeviceCount>().Invoke(myVlcInstance, outputName);
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceLongName.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceLongName.cs
@@ -7,6 +7,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public string GetAudioOutputDeviceLongName(string audioOutputDescriptionName, int deviceIndex)
         {
+            EnsureVlcInstance();
+
             using (var audioOutputDescriptionNameInterop = Utf8InteropStringConverter.ToUtf8Interop(audioOutputDescriptionName))
             {
                 return Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetAudioOutputDeviceLongName>()

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceName.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceName.cs
@@ -6,6 +6,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public string GetAudioOutputDeviceName(string audioOutputDescriptionName, int deviceIndex)
         {
+            EnsureVlcInstance();
+
             using (var audioOutputInterop = Utf8InteropStringConverter.ToUtf8Interop(audioOutputDescriptionName))
             {
                 return Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetAudioOutputDeviceName>().Invoke(myVlcInstance, audioOutputInterop.DangerousGetHandle(), deviceIndex));

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputsDescriptions.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputsDescriptions.cs
@@ -7,6 +7,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public AudioOutputDescriptionStructure GetAudioOutputsDescriptions()
         {
+            EnsureVlcInstance();
+
             return GetInteropDelegate<GetAudioOutputsDescriptions>().Invoke(myVlcInstance);
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetVideoFilterList.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetVideoFilterList.cs
@@ -7,6 +7,8 @@ namespace Vlc.DotNet.Core.Interops
     {
         public IntPtr GetVideoFilterList()
         {
+            EnsureVlcInstance();
+
             return GetInteropDelegate<GetVideoFilterList>().Invoke(myVlcInstance);
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutput.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutput.cs
@@ -12,6 +12,8 @@ namespace Vlc.DotNet.Core.Interops
 
         public void SetAudioOutput(string outputName)
         {
+            EnsureVlcInstance();
+
             using (var outputInterop = Utf8InteropStringConverter.ToUtf8Interop(outputName))
             {
                 GetInteropDelegate<SetAudioOutput>().Invoke(myVlcInstance, outputInterop.DangerousGetHandle());

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetLog.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetLog.cs
@@ -17,6 +17,9 @@ namespace Vlc.DotNet.Core.Interops
             {
                 throw new ArgumentException("Callback for log is not initialized.");
             }
+
+            EnsureVlcInstance();
+
             this._logCallbackReference = callback;
             GetInteropDelegate<SetLog>().Invoke(this.myVlcInstance, this._logCallbackReference, IntPtr.Zero);
         }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.cs
@@ -46,5 +46,6 @@ namespace Vlc.DotNet.Core.Interops
             {
                 throw new InvalidOperationException("This VlcManager has not yet been initialized. Call CreateNewInstance to initialize it.");
             }
+        }
     }
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.cs
@@ -39,5 +39,12 @@ namespace Vlc.DotNet.Core.Interops
                 myAllInstance[dynamicLinkLibrariesPath] = new VlcManager(dynamicLinkLibrariesPath);
             return myAllInstance[dynamicLinkLibrariesPath];
         }
+
+        protected void EnsureVlcInstance()
+        {
+            if (myVlcInstance == null)
+            {
+                throw new InvalidOperationException("This VlcManager has not yet been initialized. Call CreateNewInstance to initialize it.");
+            }
     }
 }


### PR DESCRIPTION
Before using myVlcInstance, make sure it is not null. If it is, throw a descriptive error message.