### PR TITLE
Support playing videos from Stream objects

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
@@ -5,55 +5,52 @@ namespace Vlc.DotNet.Core.Interops.Signatures
 {
     /// <summary>
     /// Callback prototype to open a custom bitstream input media.
-    /// NoteL: The same media item can be opened multiple times. Each time, this callback is invoked. It should allocate and initialize any instance-specific resources, then store them in *datap. The instance resources can be freed in the libvlc_media_close_cb callback.
+    /// Note: The same media item can be opened multiple times. Each time, this callback is invoked.
+    /// It should allocate and initialize any instance-specific resources, then store them in <paramref name="pData"/>.
+    /// The instance resources can be freed in the <see cref="CallbackClosemediaDelegate"/> callback.
     /// </summary>
-    /// <param name="opaque">private pointer as passed to CallbackOpenMediaDelegate()</param>
+    /// <param name="opaque">private pointer as passed to <see cref="CallbackOpenMediaDelegate"/></param>
     /// <param name="pData">storage space for a private data pointer [OUT]</param>
     /// <param name="szData">byte length of the bitstream or UINT64_MAX if unknown [OUT]</param>
-    /// <returns>0 on success, non-zero on error. In case of failure, the other callbacks will not be invoked and any value stored in *datap and *sizep is discarded.</returns>
+    /// <returns>0 on success, non-zero on error. In case of failure, the other callbacks will not be invoked and any value stored in <paramref name="pData"/> and <paramref name="szData"/> is discarded.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate Int32 CallbackOpenMediaDelegate(IntPtr opaque, out IntPtr pData, out UInt64 szData);
-    //typedef int(* libvlc_media_open_cb)(void* opaque, void** datap, uint64_t * sizep)
 
     /// <summary>
     /// Callback prototype to read data from a custom bitstream input media.
     /// Note: If no data is immediately available, then the callback should sleep.
     /// Warning: The application is responsible for avoiding deadlock situations. In particular, the callback should return an error if playback is stopped; if it does not return, then libvlc_media_player_stop() will never return.
     /// </summary>
-    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="opaque">private pointer as set by the <see cref="CallbackOpenMediaDelegate"/> callback</param>
     /// <param name="buf">start address of the buffer to read data into</param>
     /// <param name="len">bytes length of the buffer</param>
     /// <returns>strictly positive number of bytes read, 0 on end-of-stream, or -1 on non-recoverable error</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, IntPtr buf, UIntPtr len);
-    //internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] buf, UIntPtr len);
-    //typedef ssize_t(* libvlc_media_read_cb)(void* opaque, unsigned char* buf, size_t len)
 
     /// <summary>
     /// Callback prototype to seek a custom bitstream input media.
     /// </summary>
-    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="opaque">private pointer as set by the <see cref="CallbackOpenMediaDelegate"/> callback</param>
     /// <param name="offset">absolute byte offset to seek to</param>
     /// <returns>0 on success, -1 on error</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate Int32 CallbackSeekMediaDelegate(IntPtr opaque, UInt64 offset);
-    //typedef int(* libvlc_media_seek_cb)(void* opaque, uint64_t offset)
 
     /// <summary>
     /// Callback prototype to close a custom bitstream input media.
     /// </summary>
-    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="opaque">private pointer as set by the <see cref="CallbackOpenMediaDelegate"/> callback</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void CallbackCloseMediaDelegate(IntPtr opaque);
-    //typedef void(* libvlc_media_close_cb)(void* opaque)
 
     /// <summary>
     /// Create a media with custom callbacks to read the data from.
-    /// Note: If open_cb is NULL, the opaque pointer will be passed to read_cb, seek_cb and close_cb, and the stream size will be treated as unknown.
-    /// The callbacks may be called asynchronously (from another thread). A single stream instance need not be reentrant. However the open_cb needs to be reentrant if the media is used by multiple player instances.
+    /// Note: If open_cb is <see cref="IntPtr.Zero"/>, the opaque pointer will be passed to <paramref name="read_cb"/>, <paramref name="seek_cb"/> and <paramref name="close_cb"/>, and the stream size will be treated as unknown.
+    /// The callbacks may be called asynchronously (from another thread). A single stream instance need not be reentrant. However the <pararef name="open_cb needs"/> to be reentrant if the media is used by multiple player instances.
     /// Warning: The callbacks may be used until all or any player instances that were supplied the media item are stopped.
     /// </summary>
-    /// <returns>Return the newly created media or NULL on error.</returns>
+    /// <returns>Return the newly created media or <see cref="IntPtr.Zero"/> on error.</returns>
     [LibVlcFunction("libvlc_media_new_callbacks")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate IntPtr CreateNewMediaFromCallbacks(IntPtr mediaPlayerInstance,

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Vlc.DotNet.Core.Interops.Signatures
+{
+    /// <summary>
+    /// Callback prototype to open a custom bitstream input media.
+    /// NoteL: The same media item can be opened multiple times. Each time, this callback is invoked. It should allocate and initialize any instance-specific resources, then store them in *datap. The instance resources can be freed in the libvlc_media_close_cb callback.
+    /// </summary>
+    /// <param name="opaque">private pointer as passed to CallbackOpenMediaDelegate()</param>
+    /// <param name="pData">storage space for a private data pointer [OUT]</param>
+    /// <param name="szData">byte length of the bitstream or UINT64_MAX if unknown [OUT]</param>
+    /// <returns>0 on success, non-zero on error. In case of failure, the other callbacks will not be invoked and any value stored in *datap and *sizep is discarded.</returns>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate Int32 CallbackOpenMediaDelegate(IntPtr opaque, out IntPtr pData, out UInt64 szData);
+    //typedef int(* libvlc_media_open_cb)(void* opaque, void** datap, uint64_t * sizep)
+
+    /// <summary>
+    /// Callback prototype to read data from a custom bitstream input media.
+    /// Note: If no data is immediately available, then the callback should sleep.
+    /// Warning: The application is responsible for avoiding deadlock situations. In particular, the callback should return an error if playback is stopped; if it does not return, then libvlc_media_player_stop() will never return.
+    /// </summary>
+    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="buf">start address of the buffer to read data into</param>
+    /// <param name="len">bytes length of the buffer</param>
+    /// <returns>strictly positive number of bytes read, 0 on end-of-stream, or -1 on non-recoverable error</returns>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, IntPtr buf, UIntPtr len);
+    //internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] buf, UIntPtr len);
+    //typedef ssize_t(* libvlc_media_read_cb)(void* opaque, unsigned char* buf, size_t len)
+
+    /// <summary>
+    /// Callback prototype to seek a custom bitstream input media.
+    /// </summary>
+    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    /// <param name="offset">absolute byte offset to seek to</param>
+    /// <returns>0 on success, -1 on error</returns>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate Int32 CallbackSeekMediaDelegate(IntPtr opaque, UInt64 offset);
+    //typedef int(* libvlc_media_seek_cb)(void* opaque, uint64_t offset)
+
+    /// <summary>
+    /// Callback prototype to close a custom bitstream input media.
+    /// </summary>
+    /// <param name="opaque">private pointer as set by the CallbackOpenMediaDelegate() callback</param>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void CallbackCloseMediaDelegate(IntPtr opaque);
+    //typedef void(* libvlc_media_close_cb)(void* opaque)
+
+    /// <summary>
+    /// Create a media with custom callbacks to read the data from.
+    /// Note: If open_cb is NULL, the opaque pointer will be passed to read_cb, seek_cb and close_cb, and the stream size will be treated as unknown.
+    /// The callbacks may be called asynchronously (from another thread). A single stream instance need not be reentrant. However the open_cb needs to be reentrant if the media is used by multiple player instances.
+    /// Warning: The callbacks may be used until all or any player instances that were supplied the media item are stopped.
+    /// </summary>
+    /// <returns>Return the newly created media or NULL on error.</returns>
+    [LibVlcFunction("libvlc_media_new_callbacks")]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate IntPtr CreateNewMediaFromCallbacks(IntPtr mediaPlayerInstance,
+        CallbackOpenMediaDelegate open_cb,
+        CallbackReadMediaDelegate read_cb,
+        CallbackSeekMediaDelegate seek_cb,
+        CallbackCloseMediaDelegate close_cb,
+        IntPtr opaque);
+}

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
@@ -14,7 +14,7 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <param name="szData">byte length of the bitstream or UINT64_MAX if unknown [OUT]</param>
     /// <returns>0 on success, non-zero on error. In case of failure, the other callbacks will not be invoked and any value stored in <paramref name="pData"/> and <paramref name="szData"/> is discarded.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate Int32 CallbackOpenMediaDelegate(IntPtr opaque, out IntPtr pData, out UInt64 szData);
+    internal delegate int CallbackOpenMediaDelegate(IntPtr opaque, ref IntPtr pData, out ulong szData);
 
     /// <summary>
     /// Callback prototype to read data from a custom bitstream input media.
@@ -26,7 +26,7 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <param name="len">bytes length of the buffer</param>
     /// <returns>strictly positive number of bytes read, 0 on end-of-stream, or -1 on non-recoverable error</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr CallbackReadMediaDelegate(IntPtr opaque, IntPtr buf, UIntPtr len);
+    internal delegate int CallbackReadMediaDelegate(IntPtr opaque, IntPtr buf, uint len);
 
     /// <summary>
     /// Callback prototype to seek a custom bitstream input media.
@@ -35,7 +35,7 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <param name="offset">absolute byte offset to seek to</param>
     /// <returns>0 on success, -1 on error</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate Int32 CallbackSeekMediaDelegate(IntPtr opaque, UInt64 offset);
+    internal delegate int CallbackSeekMediaDelegate(IntPtr opaque, ulong offset);
 
     /// <summary>
     /// Callback prototype to close a custom bitstream input media.

--- a/src/Vlc.DotNet.Core.Interops/StreamData.cs
+++ b/src/Vlc.DotNet.Core.Interops/StreamData.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.IO;
+
+namespace Vlc.DotNet.Core.Interops
+{
+    internal class StreamData
+    {
+        public IntPtr Handle { get; set; }
+        public Stream Stream { get; set; }
+        public byte[] Buffer { get; set; }
+    }
+}

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -1,0 +1,163 @@
+﻿using System;
+#if !(NET20 || NET35)
+using System.Collections.Concurrent;
+#endif
+using System.Collections.Generic;
+using System.IO;
+using Vlc.DotNet.Core.Interops.Signatures;
+
+namespace Vlc.DotNet.Core.Interops
+{
+    public sealed partial class VlcManager
+    {
+        private static class StreamData
+        {
+            public static readonly CallbackOpenMediaDelegate CallbackOpenMediaDelegate = CallbackOpenMedia;
+            public static readonly CallbackReadMediaDelegate CallbackReadMediaDelegate = CallbackReadMedia;
+            public static readonly CallbackSeekMediaDelegate CallbackSeekMediaDelegate = CallbackSeekMedia;
+            public static readonly CallbackCloseMediaDelegate CallbackCloseMediaDelegate = CallbackCloseMedia;
+
+            private static int CallbackOpenMedia(IntPtr opaque, out IntPtr pData, out ulong szData)
+            {
+                pData = opaque;
+                try
+                {
+                    Stream stream = GetStream(opaque);
+                    szData = (ulong)stream.Length;
+                    stream.Seek(0L, SeekOrigin.Begin);
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    szData = 0UL;
+                    return -1;
+                }
+            }
+
+            private static IntPtr CallbackReadMedia(IntPtr opaque, IntPtr ipbuf, UIntPtr len)
+            {
+                try
+                {
+                    byte[] buf = new byte[(uint)len];
+                    Stream stream = GetStream(opaque);
+                    int read = stream.Read(buf, 0, (int)len);
+                    System.Runtime.InteropServices.Marshal.Copy(buf, 0, ipbuf, read);
+                    return new IntPtr(read);
+                }
+                catch (Exception ex)
+                {
+                    return new IntPtr(-1);
+                }
+            }
+            //private static IntPtr CallbackReadMedia(IntPtr opaque, byte[] buf, UIntPtr len)
+            //{
+            //    try
+            //    {
+            //        Stream stream = GetStream(opaque);
+            //        int read = stream.Read(buf, 0, (int)len);
+            //        return new IntPtr(read);
+            //    }
+            //    catch (Exception ex)
+            //    {
+            //        return new IntPtr(-1);
+            //    }
+            //}
+            private static Int32 CallbackSeekMedia(IntPtr opaque, UInt64 offset)
+            {
+                try
+                {
+                    Stream stream = GetStream(opaque);
+                    stream.Seek((long)offset, SeekOrigin.Begin);
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    return -1;
+                }
+            }
+            private static void CallbackCloseMedia(IntPtr opaque)
+            {
+                try
+                {
+                    RemoveStream(opaque);
+                }
+                catch (Exception ex)
+                {
+                }
+            }
+
+#if NET20 || NET35
+            private static readonly Dictionary<IntPtr, Stream> dicStreams = new Dictionary<IntPtr, Stream>();
+#else
+            private static readonly ConcurrentDictionary<IntPtr, Stream> dicStreams = new ConcurrentDictionary<IntPtr, Stream>();
+#endif
+
+            public static IntPtr AddStream(Stream stream)
+            {
+                IntPtr n = new IntPtr(1);
+                lock (dicStreams)
+                {
+                    for (; ;
+#if NET20 || NET35
+                        n = new IntPtr(n.ToInt64() + 1L)
+#else
+                        n = IntPtr.Add(n, 1)
+#endif
+                        )
+                    {
+                        if (n == IntPtr.Zero)
+                            return IntPtr.Zero;
+                        if (!dicStreams.ContainsKey(n))
+                            break;
+                    }
+                    dicStreams[n] = stream;
+                }
+                return n;
+            }
+            public static Stream GetStream(IntPtr n)
+            {
+#if NET20 || NET35
+                lock (dicStreams)
+                {
+                    if (!dicStreams.ContainsKey(n))
+                        return null;
+                    return dicStreams[n];
+                }
+#else
+                Stream result;
+                if (!dicStreams.TryGetValue(n, out result))
+                    return null;
+                return result;
+#endif
+            }
+            public static void RemoveStream(IntPtr n)
+            {
+#if NET20 || NET35
+                lock (dicStreams)
+                {
+                    if (dicStreams.ContainsKey(n))
+                        dicStreams.Remove(n);
+                }
+#else
+                Stream result;
+                dicStreams.TryRemove(n, out result);
+#endif
+            }
+        }
+        public VlcMediaInstance CreateNewMediaFromStream(Stream stream)
+        {
+            IntPtr opaque = StreamData.AddStream(stream);
+            if (opaque == IntPtr.Zero)
+                return null;
+            var result = VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromCallbacks>().Invoke(
+                myVlcInstance,
+                StreamData.CallbackOpenMediaDelegate,
+                StreamData.CallbackReadMediaDelegate,
+                StreamData.CallbackSeekMediaDelegate,
+                StreamData.CallbackCloseMediaDelegate,
+                opaque
+                ));
+            return result;
+        }
+    }
+}

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -44,24 +44,12 @@ namespace Vlc.DotNet.Core.Interops
                     System.Runtime.InteropServices.Marshal.Copy(buf, 0, ipbuf, read);
                     return new IntPtr(read);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return new IntPtr(-1);
                 }
             }
-            //private static IntPtr CallbackReadMedia(IntPtr opaque, byte[] buf, UIntPtr len)
-            //{
-            //    try
-            //    {
-            //        Stream stream = GetStream(opaque);
-            //        int read = stream.Read(buf, 0, (int)len);
-            //        return new IntPtr(read);
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        return new IntPtr(-1);
-            //    }
-            //}
+
             private static Int32 CallbackSeekMedia(IntPtr opaque, UInt64 offset)
             {
                 try
@@ -70,7 +58,7 @@ namespace Vlc.DotNet.Core.Interops
                     stream.Seek((long)offset, SeekOrigin.Begin);
                     return 0;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return -1;
                 }
@@ -81,7 +69,7 @@ namespace Vlc.DotNet.Core.Interops
                 {
                     RemoveStream(opaque);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                 }
             }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -142,6 +142,16 @@ namespace Vlc.DotNet.Core.Interops
                 throw new ArgumentNullException(nameof(stream));
             }
 
+            var versionString = this.VlcVersion;
+            versionString = versionString.Split('-', ' ')[0];
+
+            var version = new Version(versionString);
+
+            if (version.Major < 3)
+            {
+                throw new InvalidOperationException("You need VLC version 3.0 or higher to be able to use CreateNewMediaFromStream");
+            }
+
             IntPtr opaque = StreamData.AddStream(stream);
 
             if (opaque == IntPtr.Zero)

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -30,12 +30,7 @@ namespace Vlc.DotNet.Core.Interops
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            var versionString = this.VlcVersion;
-            versionString = versionString.Split('-', ' ')[0];
-
-            var version = new Version(versionString);
-
-            if (version.Major < 3)
+            if (VlcVersionNumber.Major < 3)
             {
                 throw new InvalidOperationException("You need VLC version 3.0 or higher to be able to use CreateNewMediaFromStream");
             }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -27,7 +27,7 @@ namespace Vlc.DotNet.Core.Interops
                     stream.Seek(0L, SeekOrigin.Begin);
                     return 0;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     szData = 0UL;
                     return -1;
@@ -102,6 +102,7 @@ namespace Vlc.DotNet.Core.Interops
                 }
                 return n;
             }
+
             public static Stream GetStream(IntPtr n)
             {
 #if NET20 || NET35
@@ -118,6 +119,7 @@ namespace Vlc.DotNet.Core.Interops
                 return result;
 #endif
             }
+
             public static void RemoveStream(IntPtr n)
             {
 #if NET20 || NET35
@@ -132,11 +134,19 @@ namespace Vlc.DotNet.Core.Interops
 #endif
             }
         }
+
         public VlcMediaInstance CreateNewMediaFromStream(Stream stream)
         {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
             IntPtr opaque = StreamData.AddStream(stream);
+
             if (opaque == IntPtr.Zero)
                 return null;
+
             var result = VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromCallbacks>().Invoke(
                 myVlcInstance,
                 StreamData.CallbackOpenMediaDelegate,
@@ -145,6 +155,7 @@ namespace Vlc.DotNet.Core.Interops
                 StreamData.CallbackCloseMediaDelegate,
                 opaque
                 ));
+
             return result;
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.cs
@@ -12,6 +12,17 @@ namespace Vlc.DotNet.Core.Interops
 
         public string VlcVersion => Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetVersion>().Invoke());
 
+        public Version VlcVersionNumber
+        {
+            get
+            {
+                var versionString = this.VlcVersion;
+                versionString = versionString.Split('-', ' ')[0];
+
+                return new Version(versionString);
+            }
+        }
+
         internal VlcManager(DirectoryInfo dynamicLinkLibrariesPath)
             : base(dynamicLinkLibrariesPath)
         {

--- a/src/Vlc.DotNet.Core/VlcMedia/VlcMedia.cs
+++ b/src/Vlc.DotNet.Core/VlcMedia/VlcMedia.cs
@@ -44,6 +44,15 @@ namespace Vlc.DotNet.Core
         {
         }
 
+        internal VlcMedia(VlcMediaPlayer player, Stream stream, params string[] options)
+#if NET20
+            : this(player, VlcMediaInstanceExtensions.AddOptionToMedia(player.Manager.CreateNewMediaFromStream(stream), player.Manager, options))
+#else
+            : this(player, player.Manager.CreateNewMediaFromStream(stream).AddOptionToMedia(player.Manager, options))
+#endif
+        {
+        }
+
         internal VlcMedia(VlcMediaPlayer player, VlcMediaInstance mediaInstance)
         {
             if(!LoadedMedias.ContainsKey(player))


### PR DESCRIPTION
This is #207 with some patches applied. I've kept the original commit; if you'd rather have the original author amend his PR that's also fine with me.

This adds support for playing videos based on .NET Stream objects. It requires VLC 3.0.

Changes w.r.t. #207:
- Allocate a buffer per stream which is used for copying data. This avoids having to allocate a new `byte[]` array every time `CallbackReadMedia` is called. This has a fairly important performance impact.
- The `Stream` does not have to be seekable
- The code performs a version check and throws an exception when not on VLC 3.0
- Some cleanup