### PR TITLE
[RFC]Exposed Core.VlcMediaPlayer and Interops.VlcManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - ADDED a method `VlcManager.CreateNewMediaFromFileDescriptor` #[314](https://github.com/ZeBobo5/Vlc.DotNet/pull/314)
 - ADDED methods `VlcMediaPlayerInstance.SetVideoCallbacks` and `VlcMediaPlayerInstance.SetVideoFormatCallbacks` #[313](https://github.com/ZeBobo5/Vlc.DotNet/pull/313)
 - ADDED overload methods to `TakeSnapshot` to be able to specify the size of the snapshot (Fixes #[211](https://github.com/ZeBobo5/Vlc.DotNet/issues/211)) #[320](https://github.com/ZeBobo5/Vlc.DotNet/pull/320)
+- ADDED public getter `VlcMediaPlayer` on WinForms `VlcControl` #[321](https://github.com/ZeBobo5/Vlc.DotNet/pull/321)
+- CHANGED visibility of `Manager` in `VlcMediaPlayer` to make it public #[321](https://github.com/ZeBobo5/Vlc.DotNet/pull/321)
 
 # 2.1.154
 - Nothing, just a few commits to change README files

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -58,7 +58,11 @@ namespace Vlc.DotNet.Core
             Audio = new AudioManagement(manager, myMediaPlayerInstance);
         }
 
-        internal VlcManager Manager { get; private set; }
+        /// <summary>
+        /// Gets the low-level interop manager that calls the methods on the libvlc library.
+        /// This is useful if a higher-level API is missing, but should be used carefully.
+        /// </summary>
+        public VlcManager Manager { get; private set; }
 
         public IntPtr VideoHostControlHandle
         {

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -59,8 +59,9 @@ namespace Vlc.DotNet.Core
         }
 
         /// <summary>
+        /// WARNING : USE AT YOUR OWN RISK!
         /// Gets the low-level interop manager that calls the methods on the libvlc library.
-        /// This is useful if a higher-level API is missing, but should be used carefully.
+        /// This is useful if a higher-level API is missing.
         /// </summary>
         public VlcManager Manager { get; private set; }
 

--- a/src/Vlc.DotNet.Forms/VlcControl.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.cs
@@ -13,6 +13,12 @@ namespace Vlc.DotNet.Forms
     {
         private VlcMediaPlayer myVlcMediaPlayer;
 
+        /// <summary>
+        /// Gets the media player.
+        /// It can be useful in order to achieve lower-level operations that are not available in the control.
+        /// </summary>
+        public VlcMediaPlayer VlcMediaPlayer => this.myVlcMediaPlayer;
+
         #region VlcControl Init
 
         public VlcControl()


### PR DESCRIPTION
It allows users to unlock features that are not yet implemented/too low-level to be implemented in the VlcControl.
What do you think about this? Is it too dangerous to let users play with the internals of this library?
Fixes #239