### PR TITLE
Warning fixes

### DIFF
--- a/src/Samples/Vlc.DotNet.Forms.Samples/Extensions/ControlExtensions.cs
+++ b/src/Samples/Vlc.DotNet.Forms.Samples/Extensions/ControlExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
             {
                 if (ctrl.InvokeRequired)
                 {
-                    ctrl.Invoke(new InvokeIfRequiredDelegate<TControl>(ControlExtensions.InvokeIfRequired), ctrl, action);
+                    ctrl.Invoke(new InvokeIfRequiredDelegate<TControl>(InvokeIfRequired), ctrl, action);
                 }
                 else
                 {

--- a/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
+++ b/src/Samples/Vlc.DotNet.Forms.Samples/Sample.cs
@@ -5,8 +5,6 @@ using System.Windows.Forms;
 
 namespace Vlc.DotNet.Forms.Samples
 {
-    using System.Diagnostics;
-
     public partial class Sample : Form
     {
         public Sample()
@@ -18,8 +16,6 @@ namespace Vlc.DotNet.Forms.Samples
         {
             var currentAssembly = Assembly.GetEntryAssembly();
             var currentDirectory = new FileInfo(currentAssembly.Location).DirectoryName;
-            if (currentDirectory == null)
-                return;
             if (IntPtr.Size == 4)
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x86\"));
             else
@@ -27,7 +23,7 @@ namespace Vlc.DotNet.Forms.Samples
 
             if (!e.VlcLibDirectory.Exists)
             {
-                var folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
+                var folderBrowserDialog = new FolderBrowserDialog();
                 folderBrowserDialog.Description = "Select Vlc libraries folder.";
                 folderBrowserDialog.RootFolder = Environment.SpecialFolder.Desktop;
                 folderBrowserDialog.ShowNewFolderButton = true;
@@ -206,7 +202,8 @@ namespace Vlc.DotNet.Forms.Samples
 
         private void OnVlcMediaPlayerLog(object sender, Core.VlcMediaPlayerLogEventArgs e)
         {
-            System.Diagnostics.Debug.WriteLine(string.Format("libVlc : {0} {1} @ {2}", e.Level, e.Message, e.Module));
+            string message = string.Format("libVlc : {0} {1} @ {2}", e.Level, e.Message, e.Module);
+            System.Diagnostics.Debug.WriteLine(message);
         }
     }
 }

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml
@@ -17,7 +17,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <wpf:VlcControl Grid.Row="0" x:Name="myControl"/>
+        <wpf:VlcControl Grid.Row="0" x:Name="MyControl"/>
 
         <Button Grid.Row="1" Click="OnPlayButtonClick">Play</Button>
         <Button Grid.Row="2" Click="OnForwardButtonClick" x:Name="Forward">Forward</Button>

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
@@ -13,13 +13,14 @@ namespace Vlc.DotNet.Wpf.Samples
         public MainWindow()
         {
             InitializeComponent();
-            myControl.MediaPlayer.VlcLibDirectoryNeeded += OnVlcControlNeedsLibDirectory;
-            myControl.MediaPlayer.EndInit();
+            MyControl.MediaPlayer.VlcLibDirectoryNeeded += OnVlcControlNeedsLibDirectory;
+            MyControl.MediaPlayer.EndInit();
 
             // This can also be called before EndInit
-            this.myControl.MediaPlayer.Log += (sender, args) =>
+            this.MyControl.MediaPlayer.Log += (sender, args) =>
             {
-                System.Diagnostics.Debug.WriteLine(string.Format("libVlc : {0} {1} @ {2}", args.Level, args.Message, args.Module));
+                string message = string.Format("libVlc : {0} {1} @ {2}", args.Level, args.Message, args.Module);
+                System.Diagnostics.Debug.WriteLine(message);
             };
         }
 
@@ -27,8 +28,6 @@ namespace Vlc.DotNet.Wpf.Samples
         {
             var currentAssembly = Assembly.GetEntryAssembly();
             var currentDirectory = new FileInfo(currentAssembly.Location).DirectoryName;
-            if (currentDirectory == null)
-                return;
             if (IntPtr.Size == 4)
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x86\"));
             else
@@ -37,29 +36,29 @@ namespace Vlc.DotNet.Wpf.Samples
 
         private void OnPlayButtonClick(object sender, RoutedEventArgs e)
         {
-            myControl.MediaPlayer.Play(new Uri("http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi"));
+            MyControl.MediaPlayer.Play(new Uri("http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi"));
             //myControl.MediaPlayer.Play(new FileInfo(@"..\..\..\Vlc.DotNet\Samples\Videos\BBB trailer.mov"));
         }
 
         private void OnForwardButtonClick(object sender, RoutedEventArgs e)
         {
-            myControl.MediaPlayer.Rate = 2;
+            MyControl.MediaPlayer.Rate = 2;
         }
 
         private void GetLength_Click(object sender, RoutedEventArgs e)
         {
-            GetLength.Content = myControl.MediaPlayer.Length + " ms";
+            GetLength.Content = MyControl.MediaPlayer.Length + " ms";
         }
 
         private void GetCurrentTime_Click(object sender, RoutedEventArgs e)
         {
-            GetCurrentTime.Content = myControl.MediaPlayer.Time + " ms";
+            GetCurrentTime.Content = MyControl.MediaPlayer.Time + " ms";
         }
 
         private void SetCurrentTime_Click(object sender, RoutedEventArgs e)
         {
-            myControl.MediaPlayer.Time = 5000;
-            SetCurrentTime.Content = myControl.MediaPlayer.Time + " ms";
+            MyControl.MediaPlayer.Time = 5000;
+            SetCurrentTime.Content = MyControl.MediaPlayer.Time + " ms";
         }
     }
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_callbacks.cs
@@ -7,7 +7,7 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// Callback prototype to open a custom bitstream input media.
     /// Note: The same media item can be opened multiple times. Each time, this callback is invoked.
     /// It should allocate and initialize any instance-specific resources, then store them in <paramref name="pData"/>.
-    /// The instance resources can be freed in the <see cref="CallbackClosemediaDelegate"/> callback.
+    /// The instance resources can be freed in the <see cref="CallbackCloseMediaDelegate"/> callback.
     /// </summary>
     /// <param name="opaque">private pointer as passed to <see cref="CallbackOpenMediaDelegate"/></param>
     /// <param name="pData">storage space for a private data pointer [OUT]</param>

--- a/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops.csproj.DotSettings
+++ b/src/Vlc.DotNet.Core.Interops/Vlc.DotNet.Core.Interops.csproj.DotSettings
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=signatures_005Clibvlc_002Eh/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=signatures_005Clibvlc_005Fevents_002Eh/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=signatures_005Clibvlc_005Fmedia_002Eh/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=signatures_005Clibvlc_005Fmedia_005Fplayer_002Eh/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewInstance.cs
@@ -1,10 +1,10 @@
-﻿namespace Vlc.DotNet.Core.Interops
-{
-    using System;
-    using System.Runtime.InteropServices;
-    using Vlc.DotNet.Core.Interops.Signatures;
-    using System.Text;
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Vlc.DotNet.Core.Interops.Signatures;
 
+namespace Vlc.DotNet.Core.Interops
+{
     public sealed partial class VlcManager
     {
         public void CreateNewInstance(string[] args)

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromStream.cs
@@ -17,9 +17,9 @@ namespace Vlc.DotNet.Core.Interops
         private static readonly CallbackCloseMediaDelegate CallbackCloseMediaDelegate = CallbackCloseMedia;
 
 #if NET20 || NET35
-        private static readonly Dictionary<IntPtr, StreamData> dicStreams = new Dictionary<IntPtr, StreamData>();
+        private static readonly Dictionary<IntPtr, StreamData> DicStreams = new Dictionary<IntPtr, StreamData>();
 #else
-        private static readonly ConcurrentDictionary<IntPtr, StreamData> dicStreams = new ConcurrentDictionary<IntPtr, StreamData>();
+        private static readonly ConcurrentDictionary<IntPtr, StreamData> DicStreams = new ConcurrentDictionary<IntPtr, StreamData>();
 #endif
         private static int streamIndex = 0;
 
@@ -89,7 +89,7 @@ namespace Vlc.DotNet.Core.Interops
             try
             {
                 var streamData = GetStream(opaque);
-                int read = 0;
+                int read;
 
                 lock (streamData)
                 {
@@ -128,6 +128,7 @@ namespace Vlc.DotNet.Core.Interops
             }
             catch (Exception)
             {
+                // ignored
             }
         }
 
@@ -140,12 +141,12 @@ namespace Vlc.DotNet.Core.Interops
 
             IntPtr handle;
 
-            lock (dicStreams)
+            lock (DicStreams)
             {
                 streamIndex++;
 
                 handle = new IntPtr(streamIndex);
-                dicStreams[handle] = new StreamData()
+                DicStreams[handle] = new StreamData()
                 {
                     Buffer = new byte[0x4000],
                     Handle = handle,
@@ -159,19 +160,19 @@ namespace Vlc.DotNet.Core.Interops
         private static StreamData GetStream(IntPtr handle)
         {
 #if NET20 || NET35
-            lock (dicStreams)
+            lock (DicStreams)
             {
-                if (!dicStreams.ContainsKey(handle))
+                if (!DicStreams.ContainsKey(handle))
                 {
                     return null;
                 }
 
-                return dicStreams[handle];
+                return DicStreams[handle];
             }
 #else
             StreamData result;
 
-            if (!dicStreams.TryGetValue(handle, out result))
+            if (!DicStreams.TryGetValue(handle, out result))
             {
                 return null;
             }
@@ -183,16 +184,16 @@ namespace Vlc.DotNet.Core.Interops
         private static void RemoveStream(IntPtr handle)
         {
 #if NET20 || NET35
-            lock (dicStreams)
+            lock (DicStreams)
             {
-                if (dicStreams.ContainsKey(handle))
+                if (DicStreams.ContainsKey(handle))
                 {
-                    dicStreams.Remove(handle);
+                    DicStreams.Remove(handle);
                 }
             }
 #else
             StreamData result;
-            dicStreams.TryRemove(handle, out result);
+            DicStreams.TryRemove(handle, out result);
 #endif
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetLogContext.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetLogContext.cs
@@ -24,21 +24,21 @@ namespace Vlc.DotNet.Core.Interops
         /// <param name="line">The source code file line number storage.</param>
         public void GetLogContext(IntPtr logContext, out string module, out string file, out uint? line)
         {
-            UIntPtr _line;
-            IntPtr _module;
-            IntPtr _file;
-            GetInteropDelegate<GetLogContext>().Invoke(logContext, out _module, out _file, out _line);
-            if (_line == UIntPtr.Zero)
+            UIntPtr line2;
+            IntPtr module2;
+            IntPtr file2;
+            GetInteropDelegate<GetLogContext>().Invoke(logContext, out module2, out file2, out line2);
+            if (line2 == UIntPtr.Zero)
             {
                 line = null;
             }
             else
             {
-                line = _line.ToUInt32();
+                line = line2.ToUInt32();
             }
 
-            module = Utf8InteropStringConverter.Utf8InteropToString(_module);
-            file = Utf8InteropStringConverter.Utf8InteropToString(_file);
+            module = Utf8InteropStringConverter.Utf8InteropToString(module2);
+            file = Utf8InteropStringConverter.Utf8InteropToString(file2);
         }
     }
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetMediaStats.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetMediaStats.cs
@@ -9,7 +9,7 @@ namespace Vlc.DotNet.Core.Interops
         {
             if (mediaInstance == IntPtr.Zero)
                 throw new ArgumentException("Media instance is not initialized.");
-            var result = new MediaStatsStructure();
+            MediaStatsStructure result;
             GetInteropDelegate<GetMediaStats>().Invoke(mediaInstance, out result);
             return result;
         }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetMediaTracksInformations.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetMediaTracksInformations.cs
@@ -10,7 +10,7 @@ namespace Vlc.DotNet.Core.Interops
         {
             if (mediaInstance == IntPtr.Zero)
                 throw new ArgumentException("Media instance is not initialized.");
-            var fullBuffer = IntPtr.Zero;
+            IntPtr fullBuffer;
             var cpt = GetInteropDelegate<GetMediaTracksInformations>().Invoke(mediaInstance, out fullBuffer);
             if (cpt <= 0)
                 return new MediaTrackInfosStructure[0];

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetLog.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetLog.cs
@@ -9,7 +9,7 @@ namespace Vlc.DotNet.Core.Interops
         /// Keeps a reference to the last callback that was given to the <see cref="SetLog"/> method.
         /// This is to avoid garbage collection of the delegate before the function is called.
         /// </summary>
-        private LogCallback _logCallbackReference;
+        private LogCallback logCallbackReference;
 
         public void SetLog(LogCallback callback)
         {
@@ -20,8 +20,8 @@ namespace Vlc.DotNet.Core.Interops
 
             EnsureVlcInstance();
 
-            this._logCallbackReference = callback;
-            GetInteropDelegate<SetLog>().Invoke(this.myVlcInstance, this._logCallbackReference, IntPtr.Zero);
+            this.logCallbackReference = callback;
+            GetInteropDelegate<SetLog>().Invoke(this.myVlcInstance, this.logCallbackReference, IntPtr.Zero);
         }
     }
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.cs
@@ -8,7 +8,7 @@ namespace Vlc.DotNet.Core.Interops
     public sealed partial class VlcManager : VlcInteropsManager
     {
         private VlcInstance myVlcInstance;
-        private static readonly Dictionary<DirectoryInfo, VlcManager> myAllInstance = new Dictionary<DirectoryInfo, VlcManager>();
+        private static readonly Dictionary<DirectoryInfo, VlcManager> MyAllInstance = new Dictionary<DirectoryInfo, VlcManager>();
 
         public string VlcVersion => Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetVersion>().Invoke());
 
@@ -33,12 +33,12 @@ namespace Vlc.DotNet.Core.Interops
             if (myVlcInstance != null)
                 myVlcInstance.Dispose();
 
-            if (myAllInstance.ContainsValue(this))
+            if (MyAllInstance.ContainsValue(this))
             {
-                foreach (var kv in new Dictionary<DirectoryInfo, VlcManager>(myAllInstance))
+                foreach (var kv in new Dictionary<DirectoryInfo, VlcManager>(MyAllInstance))
                 {
                     if(kv.Value == this)
-                        myAllInstance.Remove(kv.Key);
+                        MyAllInstance.Remove(kv.Key);
                 }
             }
             base.Dispose(disposing);
@@ -46,9 +46,9 @@ namespace Vlc.DotNet.Core.Interops
 
         public static VlcManager GetInstance(DirectoryInfo dynamicLinkLibrariesPath)
         {
-            if (!myAllInstance.ContainsKey(dynamicLinkLibrariesPath))
-                myAllInstance[dynamicLinkLibrariesPath] = new VlcManager(dynamicLinkLibrariesPath);
-            return myAllInstance[dynamicLinkLibrariesPath];
+            if (!MyAllInstance.ContainsKey(dynamicLinkLibrariesPath))
+                MyAllInstance[dynamicLinkLibrariesPath] = new VlcManager(dynamicLinkLibrariesPath);
+            return MyAllInstance[dynamicLinkLibrariesPath];
         }
 
         private void EnsureVlcInstance()

--- a/src/Vlc.DotNet.Core/Vlc.DotNet.Core.csproj.DotSettings
+++ b/src/Vlc.DotNet.Core/Vlc.DotNet.Core.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=vlcmedia/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=vlcmediaplayer/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using Vlc.DotNet.Core.Interops.Signatures;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+#if NETSTANDARD1_3
+using System.Threading.Tasks;
+#endif
+using Vlc.DotNet.Core.Interops;
 
 namespace Vlc.DotNet.Core
 {
-    using System.Runtime.InteropServices;
-    using System.Text;
-    using System.Threading;
-#if NETSTANDARD1_3
-    using System.Threading.Tasks;
-#endif
-    using Vlc.DotNet.Core.Interops;
-
     public sealed partial class VlcMediaPlayer
     {
         private object _logLock = new object();
@@ -18,12 +17,12 @@ namespace Vlc.DotNet.Core
         /// <summary>
         /// The real log event handlers.
         /// </summary>
-        private EventHandler<VlcMediaPlayerLogEventArgs> _log;
+        private EventHandler<VlcMediaPlayerLogEventArgs> log;
 
         /// <summary>
         /// A boolean to make sure that we are calling SetLog only once
         /// </summary>
-        private bool _logAttached = false;
+        private bool logAttached = false;
 
         /// <summary>
         /// The event that is triggered when a log is emitted from libVLC.
@@ -35,11 +34,11 @@ namespace Vlc.DotNet.Core
             {
                 lock (this._logLock)
                 {
-                    this._log += value;
-                    if (!this._logAttached)
+                    this.log += value;
+                    if (!this.logAttached)
                     {
                         this.Manager.SetLog(this.OnLogInternal);
-                        this._logAttached = true;
+                        this.logAttached = true;
                     }
                 }
             }
@@ -48,14 +47,14 @@ namespace Vlc.DotNet.Core
             {
                 lock (this._logLock)
                 {
-                    this._log -= value;
+                    this.log -= value;
                 }
             }
         }
 
         private void OnLogInternal(IntPtr data, VlcLogLevel level, IntPtr ctx, string format, IntPtr args)
         {
-            if (this._log != null)
+            if (this.log != null)
             {
                 // Original source for va_list handling: https://stackoverflow.com/a/37629480/2663813
                 var byteLength = Win32Interops._vscprintf(format, args) + 1;
@@ -79,11 +78,11 @@ namespace Vlc.DotNet.Core
 
                 // Do the notification on another thread, so that VLC is not interrupted by the logging
 #if NETSTANDARD1_3
-                Task.Run(() => this._log(this.myMediaPlayerInstance, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line)));
+                Task.Run(() => this.log(this.myMediaPlayerInstance, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line)));
 #else
                 ThreadPool.QueueUserWorkItem(eventArgs =>
                 {
-                    this._log(this.myMediaPlayerInstance, (VlcMediaPlayerLogEventArgs)eventArgs);
+                    this.log(this.myMediaPlayerInstance, (VlcMediaPlayerLogEventArgs)eventArgs);
                 }, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line));
 #endif
             }

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.SnapshotTaken.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.SnapshotTaken.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Vlc.DotNet.Core.Interops;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core
 {
-    using Vlc.DotNet.Core.Interops;
-
     public sealed partial class VlcMediaPlayer
     {
         private EventCallback myOnMediaPlayerSnapshotTakenInternalEventCallback;

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.TitleChanged.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.TitleChanged.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Vlc.DotNet.Core.Interops;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core
 {
-    using Vlc.DotNet.Core.Interops;
-
     public sealed partial class VlcMediaPlayer
     {
         private EventCallback myOnMediaPlayerTitleChangedInternalEventCallback;

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLogEventArgs.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLogEventArgs.cs
@@ -1,9 +1,8 @@
 ﻿using System;
+using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core
 {
-    using Vlc.DotNet.Core.Interops.Signatures;
-
     public sealed class VlcMediaPlayerLogEventArgs : EventArgs
     {
         public VlcMediaPlayerLogEventArgs(VlcLogLevel level, string message, string module, string sourceFile, uint? sourceLine)

--- a/src/Vlc.DotNet.Forms/VlcControl.Events.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.Events.cs
@@ -177,15 +177,15 @@ namespace Vlc.DotNet.Forms
         #region Log event
         private object _logLocker = new object();
 
-        private EventHandler<VlcMediaPlayerLogEventArgs> _log;
+        private EventHandler<VlcMediaPlayerLogEventArgs> log;
 
         private void OnLogInternal(object sender, VlcMediaPlayerLogEventArgs args)
         {
             lock(this._logLocker)
             {
-                if (this._log != null)
+                if (this.log != null)
                 {
-                    this._log(sender, args);
+                    this.log(sender, args);
                 }
             }
         }
@@ -201,7 +201,7 @@ namespace Vlc.DotNet.Forms
             {
                 lock (this._logLocker)
                 {
-                    this._log += value;
+                    this.log += value;
                 }
                 if (this.myVlcMediaPlayer != null)
                 {
@@ -213,7 +213,7 @@ namespace Vlc.DotNet.Forms
             {
                 lock (this._logLocker)
                 {
-                    this._log -= value;
+                    this.log -= value;
                 }
             }
         }

--- a/src/Vlc.DotNet.Forms/VlcControl.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.cs
@@ -79,7 +79,7 @@ namespace Vlc.DotNet.Forms
                 myVlcMediaPlayer = new VlcMediaPlayer(VlcLibDirectory, VlcMediaplayerOptions);
             }
 
-            if (this._log != null)
+            if (this.log != null)
             {
                 this.RegisterLogging();
             }
@@ -88,17 +88,17 @@ namespace Vlc.DotNet.Forms
             RegisterEvents();
         }
 
-        private bool _loggingRegistered = false;
+        private bool loggingRegistered = false;
 
         /// <summary>
         /// Connects (only the first time) the events from <see cref="myVlcMediaPlayer"/> to the event handlers registered on this instance
         /// </summary>
         private void RegisterLogging()
         {
-            if (this._loggingRegistered)
+            if (this.loggingRegistered)
                 return;
             this.myVlcMediaPlayer.Log += this.OnLogInternal;
-            this._loggingRegistered = true;
+            this.loggingRegistered = true;
         }
 
         // work around http://stackoverflow.com/questions/34664/designmode-with-controls/708594
@@ -125,7 +125,7 @@ namespace Vlc.DotNet.Forms
                         myVlcMediaPlayer.Dispose();
                     }
                     myVlcMediaPlayer = null;
-                    base.Dispose(disposing);
+                    base.Dispose(true);
                 }
                 disposed = true;
             }

--- a/src/Vlc.DotNet.sln.DotSettings
+++ b/src/Vlc.DotNet.sln.DotSettings
@@ -1,0 +1,7 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CSharpUsing/KeepImports/=System/@EntryIndexedValue">System</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=URL/@EntryIndexedValue">URL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/Environment/Hierarchy/PsiConfigurationSettingsKey/CustomLocation/@EntryValue">C:\Users\zavarkog\AppData\Local\JetBrains\Transient\ReSharperPlatformVs15\v08_2c0b3f11\SolutionCaches</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Most of them are inconsistent naming: private fields in the existing code has lowerCamelCase names without _ prefix) but some new logging related code uses _ prefix. Personally I also prefer the underscore prefix, but this was the smaller change to make all the same.
Similar with readonly fields in the Stream feature, usually they starts with upper case letter.