### PR TITLE
Strongly type UTf8 strings using SafeHandle

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_add_option.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_add_option.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_media_add_option")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void AddOptionToMedia(IntPtr mediaInstance, IntPtr mrl);
+    internal delegate void AddOptionToMedia(IntPtr mediaInstance, Utf8StringHandle mrl);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_add_option_flag.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_add_option_flag.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_media_add_option_flag")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void AddOptionFlagToMedia(IntPtr mediaInstance, IntPtr mrl, uint flag);
+    internal delegate void AddOptionFlagToMedia(IntPtr mediaInstance, Utf8StringHandle mrl, uint flag);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_location.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_location.cs
@@ -9,5 +9,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <returns>Return the newly created media or NULL on error.</returns>
     [LibVlcFunction("libvlc_media_new_location")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr CreateNewMediaFromLocation(IntPtr instance, IntPtr mrl);
+    internal delegate IntPtr CreateNewMediaFromLocation(IntPtr instance, Utf8StringHandle mrl);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_path.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_new_path.cs
@@ -9,5 +9,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <returns>Return the newly created media or NULL on error.</returns>
     [LibVlcFunction("libvlc_media_new_path")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr CreateNewMediaFromPath(IntPtr instance, IntPtr mrl);
+    internal delegate IntPtr CreateNewMediaFromPath(IntPtr instance, Utf8StringHandle mrl);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_set_meta.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media.h/libvlc_media_set_meta.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_media_set_meta")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetMediaMetadata(IntPtr mediaInstance, MediaMetadatas meta, IntPtr value);
+    internal delegate void SetMediaMetadata(IntPtr mediaInstance, MediaMetadatas meta, Utf8StringHandle value);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_device_id.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_device_id.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_audio_output_device_id")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr GetAudioOutputDeviceName(IntPtr instance, IntPtr audioOutputName, int deviceIndex);
+    internal delegate IntPtr GetAudioOutputDeviceName(IntPtr instance, Utf8StringHandle audioOutputName, int deviceIndex);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_device_longname.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_device_longname.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_audio_output_device_longname")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr GetAudioOutputDeviceLongName(IntPtr instance, IntPtr audioOutputName, int deviceIndex);
+    internal delegate IntPtr GetAudioOutputDeviceLongName(IntPtr instance, Utf8StringHandle audioOutputName, int deviceIndex);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_device_set.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_device_set.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_audio_output_device_set")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetAudioOutputDevice(IntPtr mediaPlayerInstance, IntPtr audioOutputName, IntPtr deviceName);
+    internal delegate void SetAudioOutputDevice(IntPtr mediaPlayerInstance, Utf8StringHandle audioOutputName, Utf8StringHandle deviceName);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_set.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_set.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_audio_output_set")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetAudioOutput(IntPtr mediaPlayerInstance, IntPtr audioOutputName);
+    internal delegate void SetAudioOutput(IntPtr mediaPlayerInstance, Utf8StringHandle audioOutputName);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_aspect_ratio.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_aspect_ratio.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_set_aspect_ratio")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetVideoAspectRatio(IntPtr mediaPlayerInstance, IntPtr cropGeometry);
+    internal delegate void SetVideoAspectRatio(IntPtr mediaPlayerInstance, Utf8StringHandle cropGeometry);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_crop_geometry.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_crop_geometry.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_set_crop_geometry")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetVideoCropGeometry(IntPtr mediaPlayerInstance, IntPtr cropGeometry);
+    internal delegate void SetVideoCropGeometry(IntPtr mediaPlayerInstance, Utf8StringHandle cropGeometry);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_deinterlace.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_deinterlace.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_set_deinterlace")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetVideoDeinterlace(IntPtr mediaPlayerInstance, IntPtr mode);
+    internal delegate void SetVideoDeinterlace(IntPtr mediaPlayerInstance, Utf8StringHandle mode);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_logo_string.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_logo_string.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_set_logo_string")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetVideoLogoString(IntPtr mediaPlayerInstance, VideoLogoOptions option, IntPtr value);
+    internal delegate void SetVideoLogoString(IntPtr mediaPlayerInstance, VideoLogoOptions option, Utf8StringHandle value);
 }

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_marquee_string.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_set_marquee_string.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_video_set_marquee_string")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetVideoMarqueeString(IntPtr mediaPlayerInstance, VideoMarqueeOptions option, IntPtr value);
+    internal delegate void SetVideoMarqueeString(IntPtr mediaPlayerInstance, VideoMarqueeOptions option, Utf8StringHandle value);
 }

--- a/src/Vlc.DotNet.Core.Interops/Utf8InteropStringConverter.cs
+++ b/src/Vlc.DotNet.Core.Interops/Utf8InteropStringConverter.cs
@@ -38,7 +38,7 @@
         /// </summary>
         /// <param name="source">The source string to be converted to UTF-8 so that it can be passed to libvlc.</param>
         /// <returns>The safe handle</returns>
-        public static SafeHandle ToUtf8Interop(string source)
+        public static Utf8StringHandle ToUtf8StringHandle(string source)
         {
             if (source == null)
             {
@@ -58,7 +58,7 @@
                 throw;
             }
 
-            return new SafeUnmanagedMemoryHandle(buffer);
+            return new Utf8StringHandle(buffer);
         }
     }
 }

--- a/src/Vlc.DotNet.Core.Interops/Utf8StringHandle.cs
+++ b/src/Vlc.DotNet.Core.Interops/Utf8StringHandle.cs
@@ -13,16 +13,16 @@
 #if !NETSTANDARD1_3
     [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
 #endif
-    internal sealed class SafeUnmanagedMemoryHandle : SafeHandle
+    public sealed class Utf8StringHandle : SafeHandle
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SafeUnmanagedMemoryHandle"/> class by providing the handle to be stored.
+        /// Initializes a new instance of the <see cref="Utf8StringHandle"/> class by providing the handle to be stored.
         /// </summary>
         /// <param name="preexistingHandle">The handle that is stored by this instance at initialization.</param>
-        internal SafeUnmanagedMemoryHandle(IntPtr preexistingHandle)
+        internal Utf8StringHandle(IntPtr stringHandle)
             : base(IntPtr.Zero, true)
         {
-            this.SetHandle(preexistingHandle);
+            this.SetHandle(stringHandle);
         }
 
         /// <summary>

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.AddOptionFlagToMedia.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.AddOptionFlagToMedia.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Text;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
@@ -12,9 +10,9 @@ namespace Vlc.DotNet.Core.Interops
             if (mediaInstance == IntPtr.Zero)
                 throw new ArgumentException("Media instance is not initialized.");
 
-            using (var handle = Utf8InteropStringConverter.ToUtf8Interop(option))
+            using (var handle = Utf8InteropStringConverter.ToUtf8StringHandle(option))
             {
-                GetInteropDelegate<AddOptionFlagToMedia>().Invoke(mediaInstance, handle.DangerousGetHandle(), flag);
+                GetInteropDelegate<AddOptionFlagToMedia>().Invoke(mediaInstance, handle, flag);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.AddOptionToMedia.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.AddOptionToMedia.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Text;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
 {
-    public sealed partial class VlcManager
+	public sealed partial class VlcManager
     {
         public void AddOptionToMedia(VlcMediaInstance mediaInstance, string option)
         {
@@ -14,9 +12,9 @@ namespace Vlc.DotNet.Core.Interops
             if (string.IsNullOrEmpty(option))
                 return;
 
-            using (var handle = Utf8InteropStringConverter.ToUtf8Interop(option))
+            using (var handle = Utf8InteropStringConverter.ToUtf8StringHandle(option))
             {
-                GetInteropDelegate<AddOptionToMedia>().Invoke(mediaInstance, handle.DangerousGetHandle());
+                GetInteropDelegate<AddOptionToMedia>().Invoke(mediaInstance, handle);
             }
         }
 

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromLocation.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromLocation.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using System.Text;
-using Vlc.DotNet.Core.Interops.Signatures;
+﻿using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
 {
@@ -10,9 +8,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             EnsureVlcInstance();
 
-            using (var handle = Utf8InteropStringConverter.ToUtf8Interop(mrl))
+            using (var handle = Utf8InteropStringConverter.ToUtf8StringHandle(mrl))
             {
-                return VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromLocation>().Invoke(myVlcInstance, handle.DangerousGetHandle()));
+                return VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromLocation>().Invoke(myVlcInstance, handle));
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromPath.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.CreateNewMediaFromPath.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using System.Text;
-using Vlc.DotNet.Core.Interops.Signatures;
+﻿using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
 {
@@ -10,9 +8,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             EnsureVlcInstance();
 
-            using (var handle = Utf8InteropStringConverter.ToUtf8Interop(mrl))
+            using (var handle = Utf8InteropStringConverter.ToUtf8StringHandle(mrl))
             {
-                return VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromPath>().Invoke(myVlcInstance, handle.DangerousGetHandle()));
+                return VlcMediaInstance.New(this, GetInteropDelegate<CreateNewMediaFromPath>().Invoke(myVlcInstance, handle));
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceLongName.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceLongName.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Vlc.DotNet.Core.Interops.Signatures;
+﻿using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
 {
@@ -9,10 +8,10 @@ namespace Vlc.DotNet.Core.Interops
         {
             EnsureVlcInstance();
 
-            using (var audioOutputDescriptionNameInterop = Utf8InteropStringConverter.ToUtf8Interop(audioOutputDescriptionName))
+            using (var audioOutputDescriptionNameInterop = Utf8InteropStringConverter.ToUtf8StringHandle(audioOutputDescriptionName))
             {
                 return Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetAudioOutputDeviceLongName>()
-                    .Invoke(myVlcInstance, audioOutputDescriptionNameInterop.DangerousGetHandle(), deviceIndex));
+                    .Invoke(myVlcInstance, audioOutputDescriptionNameInterop, deviceIndex));
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceName.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.GetAudioOutputDeviceName.cs
@@ -8,9 +8,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             EnsureVlcInstance();
 
-            using (var audioOutputInterop = Utf8InteropStringConverter.ToUtf8Interop(audioOutputDescriptionName))
+            using (var audioOutputInterop = Utf8InteropStringConverter.ToUtf8StringHandle(audioOutputDescriptionName))
             {
-                return Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetAudioOutputDeviceName>().Invoke(myVlcInstance, audioOutputInterop.DangerousGetHandle(), deviceIndex));
+                return Utf8InteropStringConverter.Utf8InteropToString(GetInteropDelegate<GetAudioOutputDeviceName>().Invoke(myVlcInstance, audioOutputInterop, deviceIndex));
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutput.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutput.cs
@@ -14,9 +14,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             EnsureVlcInstance();
 
-            using (var outputInterop = Utf8InteropStringConverter.ToUtf8Interop(outputName))
+            using (var outputInterop = Utf8InteropStringConverter.ToUtf8StringHandle(outputName))
             {
-                GetInteropDelegate<SetAudioOutput>().Invoke(myVlcInstance, outputInterop.DangerousGetHandle());
+                GetInteropDelegate<SetAudioOutput>().Invoke(myVlcInstance, outputInterop);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutputDevice.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutputDevice.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Vlc.DotNet.Core.Interops.Signatures;
+﻿using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
 {
@@ -7,10 +6,10 @@ namespace Vlc.DotNet.Core.Interops
     {
         public void SetAudioOutputDevice(VlcMediaPlayerInstance mediaPlayerInstance, string audioOutputDescriptionName, string deviceName)
         {
-            using (var audioOutputInterop = Utf8InteropStringConverter.ToUtf8Interop(audioOutputDescriptionName))
-            using (var deviceNameInterop = Utf8InteropStringConverter.ToUtf8Interop(audioOutputDescriptionName))
+            using (var audioOutputInterop = Utf8InteropStringConverter.ToUtf8StringHandle(audioOutputDescriptionName))
+            using (var deviceNameInterop = Utf8InteropStringConverter.ToUtf8StringHandle(audioOutputDescriptionName))
             {
-                GetInteropDelegate<SetAudioOutputDevice>().Invoke(mediaPlayerInstance, audioOutputInterop.DangerousGetHandle(), deviceNameInterop.DangerousGetHandle());
+                GetInteropDelegate<SetAudioOutputDevice>().Invoke(mediaPlayerInstance, audioOutputInterop, deviceNameInterop);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetMediaMeta.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetMediaMeta.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Text;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core.Interops
@@ -11,9 +9,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             if (mediaInstance == IntPtr.Zero)
                 throw new ArgumentException("Media instance is not initialized.");
-            using (var handle = Utf8InteropStringConverter.ToUtf8Interop(value))
+            using (var handle = Utf8InteropStringConverter.ToUtf8StringHandle(value))
             {
-                GetInteropDelegate<SetMediaMetadata>().Invoke(mediaInstance, metadata, handle.DangerousGetHandle());
+                GetInteropDelegate<SetMediaMetadata>().Invoke(mediaInstance, metadata, handle);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoAspectRatio.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoAspectRatio.cs
@@ -10,9 +10,9 @@ namespace Vlc.DotNet.Core.Interops
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");
 
-            using (var aspectRatioInterop = Utf8InteropStringConverter.ToUtf8Interop(aspectRatio))
+            using (var aspectRatioInterop = Utf8InteropStringConverter.ToUtf8StringHandle(aspectRatio))
             {
-                GetInteropDelegate<SetVideoAspectRatio>().Invoke(mediaPlayerInstance, aspectRatioInterop.DangerousGetHandle());
+                GetInteropDelegate<SetVideoAspectRatio>().Invoke(mediaPlayerInstance, aspectRatioInterop);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoCropGeometry.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoCropGeometry.cs
@@ -10,10 +10,10 @@ namespace Vlc.DotNet.Core.Interops
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");
 
-            using (var cropGeometryInterop = Utf8InteropStringConverter.ToUtf8Interop(cropGeometry))
+            using (var cropGeometryInterop = Utf8InteropStringConverter.ToUtf8StringHandle(cropGeometry))
             {
                 GetInteropDelegate<SetVideoCropGeometry>()
-                    .Invoke(mediaPlayerInstance, cropGeometryInterop.DangerousGetHandle());
+                    .Invoke(mediaPlayerInstance, cropGeometryInterop);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoDeinterlace.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoDeinterlace.cs
@@ -9,9 +9,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");
-            using (var deinterlaceModeInterop = Utf8InteropStringConverter.ToUtf8Interop(deinterlaceMode))
+            using (var deinterlaceModeInterop = Utf8InteropStringConverter.ToUtf8StringHandle(deinterlaceMode))
             {
-                GetInteropDelegate<SetVideoDeinterlace>().Invoke(mediaPlayerInstance, deinterlaceModeInterop.DangerousGetHandle());
+                GetInteropDelegate<SetVideoDeinterlace>().Invoke(mediaPlayerInstance, deinterlaceModeInterop);
             }
         }
     }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoLogo.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoLogo.cs
@@ -15,9 +15,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");
-            using (var valueInterop = Utf8InteropStringConverter.ToUtf8Interop(value))
+            using (var valueInterop = Utf8InteropStringConverter.ToUtf8StringHandle(value))
             {
-                GetInteropDelegate<SetVideoLogoString>().Invoke(mediaPlayerInstance, VideoLogoOptions.File, valueInterop.DangerousGetHandle());
+                GetInteropDelegate<SetVideoLogoString>().Invoke(mediaPlayerInstance, VideoLogoOptions.File, valueInterop);
             }
         }
         public void SetVideoLogoX(VlcMediaPlayerInstance mediaPlayerInstance, int value)

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoMarquee.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetVideoMarquee.cs
@@ -15,9 +15,9 @@ namespace Vlc.DotNet.Core.Interops
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");
-            using (var valueInterop = Utf8InteropStringConverter.ToUtf8Interop(value))
+            using (var valueInterop = Utf8InteropStringConverter.ToUtf8StringHandle(value))
             {
-                GetInteropDelegate<SetVideoMarqueeString>().Invoke(mediaPlayerInstance, VideoMarqueeOptions.Text, valueInterop.DangerousGetHandle());
+                GetInteropDelegate<SetVideoMarqueeString>().Invoke(mediaPlayerInstance, VideoMarqueeOptions.Text, valueInterop);
             }
         }
         public void SetVideoMarqueeColor(VlcMediaPlayerInstance mediaPlayerInstance, int value)


### PR DESCRIPTION
Rename `SafeUnmanagedMemoryHandle` to `Utf8StringHandle` - it's now used in a strongly typed fashion rather than `DangerousGetHandle()`

The `CLR` will marshal a `SafeHandle` to and from `IntPtr` automatically which makes the delegates strongly typed, you can only pass in a Utf8StringHandle which is created through Utf8InteropStringConverter. Should make the API more readable.

All the `InteropObjectInstance` classes could be removed and the delegates could be changed to use `SafeHandles`, make the code more readable/maintainable in my opinion.

Let me know what you think.