### PR TITLE
fix bug    Memory leak caused by VlcMediaPlayer.Dispose()

### DIFF
--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -90,7 +90,7 @@ namespace Vlc.DotNet.Core
             {
                 loadedMedia.Dispose();
             }
-            VlcMedia.LoadedMedias[this] = new List<VlcMedia>();
+            VlcMedia.LoadedMedias.Clear();
 
             myMediaPlayerInstance.Dispose();
             Manager.Dispose();


### PR DESCRIPTION
VlcMedia.LoadedMedias will keep adding "VlcMediaPlayer instance" when call VlcMediaPlayer.Dispose()

