### PR TITLE
Release all resources when Vlc.DotNet.Wpf.VlcControl.Dispose() called

### DIFF
--- a/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml
@@ -16,9 +16,15 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        <TabControl>
+            <TabItem Header="video">
+                <Border x:Name="videoBorder" Loaded="videoBorder_Loaded" Unloaded="videoBorder_Unloaded"/>
+            </TabItem>
+            <TabItem Header="nothing">
+                <Button Content="GC" Height="30" Width="75" Click="Button_Click"/>
+            </TabItem>
 
-        <wpf:VlcControl Grid.Row="0" x:Name="MyControl"/>
-
+        </TabControl>
         <Button Grid.Row="1" Click="OnPlayButtonClick">Play</Button>
         <Button Grid.Row="2" Click="OnForwardButtonClick" x:Name="Forward">Forward</Button>
         <Button Grid.Row="3" Click="GetLength_Click" x:Name="GetLength">Get Length</Button>

--- a/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
+++ b/src/Samples/Vlc.DotNet.Wpf.Samples/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace Vlc.DotNet.Wpf.Samples
 {
@@ -10,18 +11,10 @@ namespace Vlc.DotNet.Wpf.Samples
     /// </summary>
     public partial class MainWindow : Window
     {
+        private VlcControl MyControl;
         public MainWindow()
         {
             InitializeComponent();
-            MyControl.MediaPlayer.VlcLibDirectoryNeeded += OnVlcControlNeedsLibDirectory;
-            MyControl.MediaPlayer.EndInit();
-
-            // This can also be called before EndInit
-            this.MyControl.MediaPlayer.Log += (sender, args) =>
-            {
-                string message = string.Format("libVlc : {0} {1} @ {2}", args.Level, args.Message, args.Module);
-                System.Diagnostics.Debug.WriteLine(message);
-            };
         }
 
         private void OnVlcControlNeedsLibDirectory(object sender, Forms.VlcLibDirectoryNeededEventArgs e)
@@ -34,31 +27,95 @@ namespace Vlc.DotNet.Wpf.Samples
                 e.VlcLibDirectory = new DirectoryInfo(Path.Combine(currentDirectory, @"..\..\..\lib\x64\"));
         }
 
+        private void MediaPlayer_Log(object sender, Core.VlcMediaPlayerLogEventArgs e)
+        {
+            string message = string.Format("libVlc : {0} {1} @ {2}", e.Level, e.Message, e.Module);
+            System.Diagnostics.Debug.WriteLine(message);
+        }
+
         private void OnPlayButtonClick(object sender, RoutedEventArgs e)
         {
+            if (MyControl == null)
+            {
+                return;
+            }
             MyControl.MediaPlayer.Play(new Uri("http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi"));
             //myControl.MediaPlayer.Play(new FileInfo(@"..\..\..\Vlc.DotNet\Samples\Videos\BBB trailer.mov"));
         }
 
         private void OnForwardButtonClick(object sender, RoutedEventArgs e)
         {
+            if (MyControl == null)
+            {
+                return;
+            }
             MyControl.MediaPlayer.Rate = 2;
         }
 
         private void GetLength_Click(object sender, RoutedEventArgs e)
         {
+            if (MyControl == null)
+            {
+                return;
+            }
             GetLength.Content = MyControl.MediaPlayer.Length + " ms";
         }
 
         private void GetCurrentTime_Click(object sender, RoutedEventArgs e)
         {
+            if (MyControl == null)
+            {
+                return;
+            }
             GetCurrentTime.Content = MyControl.MediaPlayer.Time + " ms";
         }
 
         private void SetCurrentTime_Click(object sender, RoutedEventArgs e)
         {
+            if (MyControl == null)
+            {
+                return;
+            }
             MyControl.MediaPlayer.Time = 5000;
             SetCurrentTime.Content = MyControl.MediaPlayer.Time + " ms";
+        }
+
+        private void videoBorder_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (MyControl != null)
+            {
+                closeVLC();
+            }
+            initVLC();
+
+        }
+
+        private void videoBorder_Unloaded(object sender, RoutedEventArgs e)
+        {
+            closeVLC();
+        }
+
+        private void closeVLC()
+        {
+            MyControl.MediaPlayer.VlcLibDirectoryNeeded -= OnVlcControlNeedsLibDirectory;
+            MyControl.MediaPlayer.Log -= MediaPlayer_Log;
+            MyControl.Dispose();
+            MyControl = null;
+        }
+
+        private void initVLC()
+        {
+            MyControl = new VlcControl();
+            MyControl.MediaPlayer.VlcLibDirectoryNeeded += OnVlcControlNeedsLibDirectory;
+            MyControl.MediaPlayer.EndInit();
+            // This can also be called before EndInit
+            MyControl.MediaPlayer.Log += MediaPlayer_Log;
+            videoBorder.Child = MyControl;
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            GC.Collect();
         }
     }
 }

--- a/src/Vlc.DotNet.Wpf/VlcControl.cs
+++ b/src/Vlc.DotNet.Wpf/VlcControl.cs
@@ -1,19 +1,52 @@
 using System;
-using System.Runtime.InteropServices;
-using System.Windows.Interop;
-using Vlc.DotNet.Core.Interops;
 using System.Windows.Forms.Integration;
+using System.Windows.Controls;
 
 namespace Vlc.DotNet.Wpf
 {
-    public class VlcControl : WindowsFormsHost
+    public class VlcControl : UserControl, IDisposable
     {
         public Forms.VlcControl MediaPlayer { get; private set; }
 
+        private WindowsFormsHost _host;
+        private Border _border;
+
         public VlcControl()
         {
+            _border = new Border();
+            _host = new WindowsFormsHost();
             MediaPlayer = new Forms.VlcControl();
-            this.Child = MediaPlayer; 
+            _host.Child = MediaPlayer;
+            _border.Child = _host;
+            Content = _border;
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _border.Child = null;
+                    _host.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+
+        ~VlcControl()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Vlc.DotNet.Wpf.VlcControl is WindowsFormsHost, we need to call "Dispose()" to release resources.

If we need to repeatedly instantiate VlcControls in a program, we need to release resources at the right time.

if VlcControl is on the LogicTree，we must disconnect VlcControl from the LogicTree before calling the "Dispose()" .

Just like this:
private void closeVLC()
{
    MyControl.MediaPlayer.VlcLibDirectoryNeeded -= OnVlcControlNeedsLibDirectory;
    MyControl.MediaPlayer.Log -= MediaPlayer_Log;
    videoBorder.Child = null;   //disconnect VlcControl from the LogicTree 
    MyControl.Dispose();    //release resources
    MyControl = null;
}

private void initVLC()
{
    MyControl = new VlcControl();
    MyControl.MediaPlayer.VlcLibDirectoryNeeded += OnVlcControlNeedsLibDirectory;
    MyControl.MediaPlayer.EndInit();
    // This can also be called before EndInit
    MyControl.MediaPlayer.Log += MediaPlayer_Log;
    videoBorder.Child = MyControl;
}

if VlcControl is System.Windows.Controls.UserControl and implements the IDisposable interface. we can disconnect VlcControl from the LogicTree before WindowsFormsHost.Dispose() when VlcControl.Dispose() called. Look like a common WPF UserControl.


