### PR TITLE
#362 Fix bug in media title

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_events.h/libvlc_event_t.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_events.h/libvlc_event_t.cs
@@ -163,9 +163,8 @@ namespace Vlc.DotNet.Core.Interops.Signatures
 
     [StructLayout(LayoutKind.Sequential)]
     public struct MediaPlayerTitleChanged
-    {
-        //todo : original was int : Check if ok
-        public IntPtr NewTitle;
+    {        
+        public int NewTitle;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.TitleChanged.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.TitleChanged.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using Vlc.DotNet.Core.Interops;
 using Vlc.DotNet.Core.Interops.Signatures;
 
 namespace Vlc.DotNet.Core
@@ -17,15 +16,14 @@ namespace Vlc.DotNet.Core
 #else
             var args = Marshal.PtrToStructure<VlcEventArg>(ptr);
 #endif
-            var fileName = Utf8InteropStringConverter.Utf8InteropToString(args.eventArgsUnion.MediaPlayerTitleChanged.NewTitle);
-            OnMediaPlayerTitleChanged(fileName);
+            OnMediaPlayerTitleChanged(args.eventArgsUnion.MediaPlayerTitleChanged.NewTitle);
         }
 
-        public void OnMediaPlayerTitleChanged(string fileName)
+        public void OnMediaPlayerTitleChanged(int newTitle)
         {
             var del = TitleChanged;
             if (del != null)
-                del(this, new VlcMediaPlayerTitleChangedEventArgs(fileName));
+                del(this, new VlcMediaPlayerTitleChangedEventArgs(newTitle));
         }
     }
 }

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerTitleChangedEventArgs.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerTitleChangedEventArgs.cs
@@ -4,11 +4,11 @@ namespace Vlc.DotNet.Core
 {
     public sealed class VlcMediaPlayerTitleChangedEventArgs : EventArgs
     {
-        public VlcMediaPlayerTitleChangedEventArgs(string newTitle)
+        public VlcMediaPlayerTitleChangedEventArgs(int newTitle)
         {
             NewTitle = newTitle;
         }
 
-        public string NewTitle { get; private set; }
+        public int NewTitle { get; private set; }
     }
 }

--- a/src/Vlc.DotNet.Forms/VlcControl.Events.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.Events.cs
@@ -432,7 +432,7 @@ namespace Vlc.DotNet.Forms
         [Category("Media Player")]
         public event EventHandler<VlcMediaPlayerTitleChangedEventArgs> TitleChanged;
 
-        public void OnTitleChanged(string newTitle)
+        public void OnTitleChanged(int newTitle)
         {
             lock (myEventSyncLocker)
             {


### PR DESCRIPTION
Fix System.AccessViolationException when playing files with a title in the metadata.
Title was being treated as a string but represents the index of the "Title" being played.