### PR TITLE
Refactoring of the TakeSnapshot method

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_take_snapshot.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_video_take_snapshot.cs
@@ -9,5 +9,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// <returns>Return 0 on success, -1 if the video was not found.</returns>
     [LibVlcFunction("libvlc_video_take_snapshot")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int TakeSnapshot(IntPtr mediaPlayerInstance, uint num, string fileName, uint width, uint height);
+    internal delegate int TakeSnapshot(IntPtr mediaPlayerInstance, uint num, Utf8StringHandle fileName, uint width, uint height);
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.TakeSnapshot.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.TakeSnapshot.cs
@@ -6,13 +6,16 @@ namespace Vlc.DotNet.Core.Interops
 {
     public sealed partial class VlcManager
     {
-        public void TakeSnapshot(VlcMediaPlayerInstance mediaPlayerInstance, FileInfo file, uint width, uint height)
+        public bool TakeSnapshot(VlcMediaPlayerInstance mediaPlayerInstance, uint outputNumber, string filePath, uint width, uint height)
         {
             if (mediaPlayerInstance == IntPtr.Zero)
                 throw new ArgumentException("Media player instance is not initialized.");
-            if(file == null)
-                throw new ArgumentNullException("file");
-            GetInteropDelegate<TakeSnapshot>().Invoke(mediaPlayerInstance, 0, file.FullName, width, height);
+            if(filePath == null)
+                throw new ArgumentNullException(nameof(filePath));
+            using (var filePathHandle = Utf8InteropStringConverter.ToUtf8StringHandle(filePath))
+            {
+                return GetInteropDelegate<TakeSnapshot>().Invoke(mediaPlayerInstance, outputNumber, filePathHandle, width, height) == 0;
+            }
         }
     }
 }

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -334,13 +334,31 @@ namespace Vlc.DotNet.Core
             set { Manager.SetVideoSpu(myMediaPlayerInstance, value); }
         }
 
-        public void TakeSnapshot(FileInfo file)
+        public bool TakeSnapshot(FileInfo file)
         {
-            TakeSnapshot(file, 0, 0);
+            return TakeSnapshot(file, 0, 0);
         }
-        public void TakeSnapshot(FileInfo file, uint width, uint height)
+
+        public bool TakeSnapshot(FileInfo file, uint width, uint height)
         {
-            Manager.TakeSnapshot(myMediaPlayerInstance, file, width, height);
+            return TakeSnapshot(0, file.FullName, width, height);
+        }
+
+        /// <summary>
+        /// Take a snapshot of the current video window.
+        /// </summary>
+        /// <param name="outputNumber">The number of video output (typically 0 for the first/only one)</param>
+        /// <param name="file">The path of a file or a folder to save the screenshot into</param>
+        /// <param name="width">the snapshot's width</param>
+        /// <param name="height">the snapshot's height</param>
+        /// <returns>A boolean indicating whether the screenshot was sucessfully taken</returns>
+        /// <remarks>
+        /// If i_width AND i_height is 0, original size is used.
+        /// If i_width XOR i_height is 0, original aspect-ratio is preserved.
+        /// </remarks>
+        public bool TakeSnapshot(uint outputNumber, string file, uint width, uint height)
+        {
+            return Manager.TakeSnapshot(myMediaPlayerInstance, outputNumber, file, width, height);
         }
 
         private void RegisterEvents()


### PR DESCRIPTION
- Allow unicode file names
- Allow the selection of a folder rather than a file (string rather than
FileInfo)
- Allow the selection of the video output where the snapshot should be
taken. This is to align Vlc.DotNet with the libvlc API.