### PR TITLE
Adding support of rendering videos with alpha channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - FIXED Dispose() in WPF project [#358](https://github.com/ZeBobo5/Vlc.DotNet/pull/358)
 - CHANGED name of internal handle class from `SafeUnmanagedMemoryHandle` to `Utf8StringHandle` [#337](https://github.com/ZeBobo5/Vlc.DotNet/pull/337)
 - ADDED : `SetMouseInput`/`SetKeyInput` methods [#424](https://github.com/ZeBobo5/Vlc.DotNet/pull/424). Fixes [#379](https://github.com/ZeBobo5/Vlc.DotNet/issues/379) and [#107](https://github.com/ZeBobo5/Vlc.DotNet/issues/107). Thanks @CrookedFingerGuy
+- ADDED : Rendering support for alpha channel videos in WPF control [#425](https://github.com/ZeBobo5/Vlc.DotNet/pull/425)
 
 # 2.2.1
 - FIXED assembly file version that was incorrect #[326](https://github.com/ZeBobo5/Vlc.DotNet/pull/326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - FIXED Dispose() in WPF project [#358](https://github.com/ZeBobo5/Vlc.DotNet/pull/358)
 - CHANGED name of internal handle class from `SafeUnmanagedMemoryHandle` to `Utf8StringHandle` [#337](https://github.com/ZeBobo5/Vlc.DotNet/pull/337)
 - ADDED : `SetMouseInput`/`SetKeyInput` methods [#424](https://github.com/ZeBobo5/Vlc.DotNet/pull/424). Fixes [#379](https://github.com/ZeBobo5/Vlc.DotNet/issues/379) and [#107](https://github.com/ZeBobo5/Vlc.DotNet/issues/107). Thanks @CrookedFingerGuy
-- ADDED : Rendering support for alpha channel videos in WPF control [#425](https://github.com/ZeBobo5/Vlc.DotNet/pull/425)
+- ADDED : Rendering support for alpha channel videos in WPF control [#439](https://github.com/ZeBobo5/Vlc.DotNet/pull/439)
 
 # 2.2.1
 - FIXED assembly file version that was incorrect #[326](https://github.com/ZeBobo5/Vlc.DotNet/pull/326)

--- a/src/Vlc.DotNet.Wpf/VlcControl.cs
+++ b/src/Vlc.DotNet.Wpf/VlcControl.cs
@@ -12,6 +12,11 @@ namespace Vlc.DotNet.Wpf
     public class VlcControl: UserControl, IDisposable
     {
         /// <summary>
+        /// Stores the previous <see cref="Control.Background"/> brush after switching IsAlphaChannelEnabled to true
+        /// </summary>
+        private Brush previousBrush;
+
+        /// <summary>
         /// The Viewbox that contains the video image
         /// </summary>
         private Viewbox viewBox;
@@ -27,6 +32,22 @@ namespace Vlc.DotNet.Wpf
         private readonly VlcVideoSourceProvider sourceProvider;
 
         public VlcVideoSourceProvider SourceProvider => sourceProvider;
+
+        /// <summary>
+        /// Defines if <see cref="VlcVideoSourceProvider.VideoSource"/> pixel format is <see cref="PixelFormats.Bgr32"/> or <see cref="PixelFormats.Bgra32"/>
+        /// </summary>
+        public bool IsAlphaChannelEnabled
+        {
+            get
+            {
+                return sourceProvider.IsAlphaChannelEnabled;
+            }
+
+            set
+            {
+                sourceProvider.IsAlphaChannelEnabled = value;
+            }
+        }
         
         /// <summary>
         /// The constructor
@@ -44,12 +65,31 @@ namespace Vlc.DotNet.Wpf
             this.Background = Brushes.Black;
             // Binds the VideoSource to the Image.Source property
             this.videoContent.SetBinding(Image.SourceProperty, new Binding(nameof(VlcVideoSourceProvider.VideoSource)) { Source = sourceProvider });
+            //Listen PropertyChanged event to define if IsAlphaChannelEnabled is true or false
+            this.sourceProvider.PropertyChanged += SourceProvider_PropertyChanged;
         }
 
         /// <inheritdoc />
         public void Dispose()
         {
             sourceProvider.Dispose();
+        }
+
+        private void SourceProvider_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if(e.PropertyName == nameof(VlcVideoSourceProvider.IsAlphaChannelEnabled))
+            {
+                if(this.sourceProvider.IsAlphaChannelEnabled)
+                {
+                    previousBrush = Background;
+                    Background = Brushes.Transparent;
+                }
+                else
+                {
+                    var _previousBrush = previousBrush == null ? Brushes.Black : previousBrush;
+                    Background = _previousBrush;
+                }
+            }
         }
     }
 }

--- a/src/Vlc.DotNet.Wpf/VlcControl.cs
+++ b/src/Vlc.DotNet.Wpf/VlcControl.cs
@@ -12,11 +12,6 @@ namespace Vlc.DotNet.Wpf
     public class VlcControl: UserControl, IDisposable
     {
         /// <summary>
-        /// Stores the previous <see cref="Control.Background"/> brush after switching IsAlphaChannelEnabled to true
-        /// </summary>
-        private Brush previousBrush;
-
-        /// <summary>
         /// The Viewbox that contains the video image
         /// </summary>
         private Viewbox viewBox;
@@ -65,31 +60,12 @@ namespace Vlc.DotNet.Wpf
             this.Background = Brushes.Black;
             // Binds the VideoSource to the Image.Source property
             this.videoContent.SetBinding(Image.SourceProperty, new Binding(nameof(VlcVideoSourceProvider.VideoSource)) { Source = sourceProvider });
-            //Listen PropertyChanged event to define if IsAlphaChannelEnabled is true or false
-            this.sourceProvider.PropertyChanged += SourceProvider_PropertyChanged;
         }
 
         /// <inheritdoc />
         public void Dispose()
         {
             sourceProvider.Dispose();
-        }
-
-        private void SourceProvider_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if(e.PropertyName == nameof(VlcVideoSourceProvider.IsAlphaChannelEnabled))
-            {
-                if(this.sourceProvider.IsAlphaChannelEnabled)
-                {
-                    previousBrush = Background;
-                    Background = Brushes.Transparent;
-                }
-                else
-                {
-                    var _previousBrush = previousBrush == null ? Brushes.Black : previousBrush;
-                    Background = _previousBrush;
-                }
-            }
         }
     }
 }

--- a/src/Vlc.DotNet.Wpf/VlcVideoSourceProvider.cs
+++ b/src/Vlc.DotNet.Wpf/VlcVideoSourceProvider.cs
@@ -44,6 +44,7 @@ namespace Vlc.DotNet.Wpf
         private IntPtr memoryMappedView;
 #endif
         private bool isAlphaChannelEnabled;
+        private bool playerCreated;
 
         private ImageSource videoSource;
 
@@ -89,8 +90,10 @@ namespace Vlc.DotNet.Wpf
 
             set
             {
-                this.isAlphaChannelEnabled = value;
-                this.OnPropertyChanged(nameof(IsAlphaChannelEnabled));
+                if (!playerCreated)
+                    this.isAlphaChannelEnabled = value;
+                else
+                    throw new InvalidOperationException("IsAlphaChannelEnabled property should be changed only before CreatePlayer method is called.");
             }
         }
 
@@ -107,6 +110,8 @@ namespace Vlc.DotNet.Wpf
 
             this.MediaPlayer.SetVideoFormatCallbacks(this.VideoFormat, this.CleanupVideo);
             this.MediaPlayer.SetVideoCallbacks(LockVideo, null, DisplayVideo, IntPtr.Zero);
+
+            playerCreated = true;
         }
 
         /// <summary>

--- a/src/Vlc.DotNet.Wpf/VlcVideoSourceProvider.cs
+++ b/src/Vlc.DotNet.Wpf/VlcVideoSourceProvider.cs
@@ -43,7 +43,7 @@ namespace Vlc.DotNet.Wpf
         /// </summary>
         private IntPtr memoryMappedView;
 #endif
-        
+
         private ImageSource videoSource;
 
         private Dispatcher dispatcher;
@@ -79,6 +79,11 @@ namespace Vlc.DotNet.Wpf
         public VlcMediaPlayer MediaPlayer { get; private set; }
 
         /// <summary>
+        /// Defines if <see cref="VideoSource"/> pixel format is <see cref="PixelFormats.Bgr32"/> or <see cref="PixelFormats.Bgra32"/>
+        /// </summary>
+        public bool IsAlphaChannelEnabled { get; set; }
+
+        /// <summary>
         /// Creates the player. This method must be called before using <see cref="MediaPlayer"/>
         /// </summary>
         /// <param name="vlcLibDirectory">The directory where to find the vlc library</param>
@@ -110,7 +115,7 @@ namespace Vlc.DotNet.Wpf
             return dimension + mod - (dimension % mod);
         }
 
-#region Vlc video callbacks
+        #region Vlc video callbacks
         /// <summary>
         /// Called by vlc when the video format is needed. This method allocats the picture buffers for vlc and tells it to set the chroma to RV32
         /// </summary>
@@ -123,10 +128,10 @@ namespace Vlc.DotNet.Wpf
         /// <returns>The number of buffers allocated</returns>
         private uint VideoFormat(out IntPtr userdata, IntPtr chroma, ref uint width, ref uint height, ref uint pitches, ref uint lines)
         {
-            var pixelFormat = PixelFormats.Bgr32;
+            var pixelFormat = IsAlphaChannelEnabled ? PixelFormats.Bgra32 : PixelFormats.Bgr32;
             FourCCConverter.ToFourCC("RV32", chroma);
 
-            pitches = this.GetAlignedDimension((uint)(width*pixelFormat.BitsPerPixel) / 8, 32);
+            pitches = this.GetAlignedDimension((uint)(width * pixelFormat.BitsPerPixel) / 8, 32);
             lines = this.GetAlignedDimension(height, 32);
 
             var size = pitches * lines;
@@ -196,7 +201,7 @@ namespace Vlc.DotNet.Wpf
         private void DisplayVideo(IntPtr userdata, IntPtr picture)
         {
             // Invalidates the bitmap
-            this.dispatcher.BeginInvoke((Action) (() =>
+            this.dispatcher.BeginInvoke((Action)(() =>
             {
                 (this.VideoSource as InteropBitmap)?.Invalidate();
             }));
@@ -228,7 +233,7 @@ namespace Vlc.DotNet.Wpf
 
         #region IDisposable Support
         private bool disposedValue = false;
-        
+
         /// <summary>
         /// Disposes the control.
         /// </summary>
@@ -247,8 +252,9 @@ namespace Vlc.DotNet.Wpf
         /// <summary>
         /// The destructor
         /// </summary>
-        ~VlcVideoSourceProvider() {
-           Dispose(false);
+        ~VlcVideoSourceProvider()
+        {
+            Dispose(false);
         }
 
         /// <inheritdoc />
@@ -257,7 +263,7 @@ namespace Vlc.DotNet.Wpf
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-#endregion
+        #endregion
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/src/Vlc.DotNet.Wpf/VlcVideoSourceProvider.cs
+++ b/src/Vlc.DotNet.Wpf/VlcVideoSourceProvider.cs
@@ -43,6 +43,7 @@ namespace Vlc.DotNet.Wpf
         /// </summary>
         private IntPtr memoryMappedView;
 #endif
+        private bool isAlphaChannelEnabled;
 
         private ImageSource videoSource;
 
@@ -81,7 +82,17 @@ namespace Vlc.DotNet.Wpf
         /// <summary>
         /// Defines if <see cref="VideoSource"/> pixel format is <see cref="PixelFormats.Bgr32"/> or <see cref="PixelFormats.Bgra32"/>
         /// </summary>
-        public bool IsAlphaChannelEnabled { get; set; }
+        public bool IsAlphaChannelEnabled { get
+            {
+                return this.isAlphaChannelEnabled;
+            }
+
+            set
+            {
+                this.isAlphaChannelEnabled = value;
+                this.OnPropertyChanged(nameof(IsAlphaChannelEnabled));
+            }
+        }
 
         /// <summary>
         /// Creates the player. This method must be called before using <see cref="MediaPlayer"/>


### PR DESCRIPTION
Just a small change to make videos with alpha channel supported.
You can test it if `IsAlphaChannelEnabled` property in `VlcVideoSourceProvider` is set to true and play video with alpha channel like one of [this](http://vidvox.net/media_share/pacificCoastDemoHap480p.zip)