### PR TITLE
Bug fix/propagate float to long

### DIFF
--- a/src/Samples/Samples.WinForms.Advanced/Sample.cs
+++ b/src/Samples/Samples.WinForms.Advanced/Sample.cs
@@ -60,7 +60,7 @@ namespace Samples.WinForms.Advanced
 
         private void OnVlcMediaLengthChanged(object sender, VlcMediaPlayerLengthChangedEventArgs e)
         {
-            myLblMediaLength.InvokeIfRequired(l => l.Text = new DateTime(new TimeSpan((long)e.NewLength).Ticks).ToString("T"));
+            myLblMediaLength.InvokeIfRequired(l => l.Text = new DateTime(new TimeSpan(e.NewLength).Ticks).ToString("T"));
         }
 
         private void OnVlcPositionChanged(object sender, VlcMediaPlayerPositionChangedEventArgs e)

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.LengthChanged.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.LengthChanged.cs
@@ -12,10 +12,10 @@ namespace Vlc.DotNet.Core
         private void OnMediaPlayerLengthChangedInternal(IntPtr ptr)
         {
             var args = MarshalHelper.PtrToStructure<VlcEventArg>(ptr);
-            OnMediaPlayerLengthChanged(args.eventArgsUnion.MediaPlayerLengthChanged.NewLength * 10000);
+            OnMediaPlayerLengthChanged(args.eventArgsUnion.MediaPlayerLengthChanged.NewLength);
         }
 
-        public void OnMediaPlayerLengthChanged(float newLength)
+        public void OnMediaPlayerLengthChanged(long newLength)
         {
             LengthChanged?.Invoke(this, new VlcMediaPlayerLengthChangedEventArgs(newLength));
         }

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLengthChangedEventArgs.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayerLengthChangedEventArgs.cs
@@ -4,11 +4,11 @@ namespace Vlc.DotNet.Core
 {
     public sealed class VlcMediaPlayerLengthChangedEventArgs : EventArgs
     {
-        public VlcMediaPlayerLengthChangedEventArgs(float newLength)
+        public VlcMediaPlayerLengthChangedEventArgs(long newLength)
         {
             NewLength = newLength;
         }
 
-        public float NewLength { get; private set; }
+        public long NewLength { get; private set; }
     }
 }

--- a/src/Vlc.DotNet.Forms/VlcControl.Events.cs
+++ b/src/Vlc.DotNet.Forms/VlcControl.Events.cs
@@ -163,7 +163,7 @@ namespace Vlc.DotNet.Forms
         [Category("Media Player")]
         public event EventHandler<VlcMediaPlayerLengthChangedEventArgs> LengthChanged;
 
-        public void OnLengthChanged(float newLength)
+        public void OnLengthChanged(long newLength)
         {
             lock (myEventSyncLocker)
             {


### PR DESCRIPTION
According to [this](https://github.com/ZeBobo5/Vlc.DotNet/issues/4#issuecomment-427562904) thread I've changed float types to long for  

>  e.NewLength;

```
private void OnVlcMediaLengthChanged(object sender, VlcMediaPlayerLengthChangedEventArgs e)
        {
           e.NewLength;
        }
```

and I've tested the project.