### PR TITLE
#492 Setting Audio.Outputs.Current property throws AccessViolationExc…

### DIFF
--- a/src/Samples/Samples.WinForms.Advanced/Sample.Designer.cs
+++ b/src/Samples/Samples.WinForms.Advanced/Sample.Designer.cs
@@ -54,6 +54,8 @@
             this.myBtnEnableMouseEvents = new System.Windows.Forms.Button();
             this.myBtnDisableMouseEvents = new System.Windows.Forms.Button();
             this.myVlcControl = new Vlc.DotNet.Forms.VlcControl();
+            this.label4 = new System.Windows.Forms.Label();
+            this.myCbxAudioOutputs = new System.Windows.Forms.ComboBox();
             this.myGrpAudioInformations.SuspendLayout();
             this.myGrpVideoInformations.SuspendLayout();
             this.myGrpMouseInformations.SuspendLayout();
@@ -296,20 +298,20 @@
             this.myLblKeyDown.TabIndex = 0;
             this.myLblKeyDown.Text = "Key Down: false";
             // 
-            // myBtnDisableMouseEvents
+            // myBtnEnableMouseEvents
             // 
             this.myBtnEnableMouseEvents.Location = new System.Drawing.Point(583, 309);
-            this.myBtnEnableMouseEvents.Name = "myBtnDisableMouseEvents";
+            this.myBtnEnableMouseEvents.Name = "myBtnEnableMouseEvents";
             this.myBtnEnableMouseEvents.Size = new System.Drawing.Size(159, 23);
             this.myBtnEnableMouseEvents.TabIndex = 15;
             this.myBtnEnableMouseEvents.Text = "Enable Player Input Events";
             this.myBtnEnableMouseEvents.UseVisualStyleBackColor = true;
             this.myBtnEnableMouseEvents.Click += new System.EventHandler(this.myBtnEnableMouseEvents_Click);
             // 
-            // myBtnEnableMouseEvents
+            // myBtnDisableMouseEvents
             // 
             this.myBtnDisableMouseEvents.Location = new System.Drawing.Point(583, 280);
-            this.myBtnDisableMouseEvents.Name = "myBtnEnableMouseEvents";
+            this.myBtnDisableMouseEvents.Name = "myBtnDisableMouseEvents";
             this.myBtnDisableMouseEvents.Size = new System.Drawing.Size(159, 23);
             this.myBtnDisableMouseEvents.TabIndex = 16;
             this.myBtnDisableMouseEvents.Text = "Disable Player Input Events";
@@ -346,11 +348,36 @@
             this.myVlcControl.MouseLeave += new System.EventHandler(this.myVlcControl_MouseLeave);
             this.myVlcControl.MouseUp += new System.Windows.Forms.MouseEventHandler(this.myVlcControl_MouseUp);
             // 
+            // label4
+            // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(580, 341);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(72, 13);
+            this.label4.TabIndex = 18;
+            this.label4.Text = "Audio Output:";
+            // 
+            // myCbxAudioOutputs
+            // 
+            this.myCbxAudioOutputs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.myCbxAudioOutputs.FormattingEnabled = true;
+            this.myCbxAudioOutputs.Items.AddRange(new object[] {
+            "16:9",
+            "16:10",
+            "4:3"});
+            this.myCbxAudioOutputs.Location = new System.Drawing.Point(658, 338);
+            this.myCbxAudioOutputs.Name = "myCbxAudioOutputs";
+            this.myCbxAudioOutputs.Size = new System.Drawing.Size(143, 21);
+            this.myCbxAudioOutputs.TabIndex = 17;
+            // 
             // Sample
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(813, 391);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.myCbxAudioOutputs);
             this.Controls.Add(this.myBtnDisableMouseEvents);
             this.Controls.Add(this.myBtnEnableMouseEvents);
             this.Controls.Add(this.myGrpMouseInformations);
@@ -410,6 +437,8 @@
         private System.Windows.Forms.Label myLblKeyDown;
         private System.Windows.Forms.Button myBtnEnableMouseEvents;
         private System.Windows.Forms.Button myBtnDisableMouseEvents;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.ComboBox myCbxAudioOutputs;
     }
 }
 

--- a/src/Samples/Samples.WinForms.Advanced/Sample.Designer.cs
+++ b/src/Samples/Samples.WinForms.Advanced/Sample.Designer.cs
@@ -362,10 +362,6 @@
             // 
             this.myCbxAudioOutputs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.myCbxAudioOutputs.FormattingEnabled = true;
-            this.myCbxAudioOutputs.Items.AddRange(new object[] {
-            "16:9",
-            "16:10",
-            "4:3"});
             this.myCbxAudioOutputs.Location = new System.Drawing.Point(658, 338);
             this.myCbxAudioOutputs.Name = "myCbxAudioOutputs";
             this.myCbxAudioOutputs.Size = new System.Drawing.Size(143, 21);

--- a/src/Samples/Samples.WinForms.Advanced/Sample.cs
+++ b/src/Samples/Samples.WinForms.Advanced/Sample.cs
@@ -18,10 +18,6 @@ namespace Samples.WinForms.Advanced
         {
             InitializeComponent();
 
-            //int result = myVlcControl.VlcMediaPlayer.SetAudioOutput("mmdevice");
-            //int result = myVlcControl.VlcMediaPlayer.SetAudioOutput("directshow");
-            //int result = myVlcControl.VlcMediaPlayer.SetAudioOutput("_sdfsdf");
-
             if (myVlcControl.Audio != null)
             {
                 var outputs = myVlcControl.Audio.Outputs;

--- a/src/Samples/Samples.WinForms.Advanced/Sample.cs
+++ b/src/Samples/Samples.WinForms.Advanced/Sample.cs
@@ -7,6 +7,9 @@ using Vlc.DotNet.Core.Interops;
 using Vlc.DotNet.Core.Interops.Signatures;
 using Vlc.DotNet.Forms;
 
+using System.Linq;
+using System.Collections.Generic;
+
 namespace Samples.WinForms.Advanced
 {
     public partial class Sample : Form
@@ -14,6 +17,36 @@ namespace Samples.WinForms.Advanced
         public Sample()
         {
             InitializeComponent();
+
+            //int result = myVlcControl.VlcMediaPlayer.SetAudioOutput("mmdevice");
+            //int result = myVlcControl.VlcMediaPlayer.SetAudioOutput("directshow");
+            //int result = myVlcControl.VlcMediaPlayer.SetAudioOutput("_sdfsdf");
+
+            if (myVlcControl.Audio != null)
+            {
+                var outputs = myVlcControl.Audio.Outputs;
+                if (outputs != null)
+                {
+
+                    myCbxAudioOutputs.DataSource = new List<AudioOutputDescription>(outputs.All);
+                    myCbxAudioOutputs.DisplayMember = "Description";
+                    myCbxAudioOutputs.Enabled = true;
+                    myCbxAudioOutputs.SelectedIndex = -1;
+                    myCbxAudioOutputs.SelectedValueChanged += (o, a) =>
+                    {
+                        var val = myCbxAudioOutputs.SelectedValue;
+                        if (val != null)
+                        {
+                            var output = val as AudioOutputDescription;
+                            if (output != null)
+                            {
+                                outputs.Current = output;
+                            }
+                        }
+                    };
+
+                }
+            }
         }
 
         /// <summary>

--- a/src/Samples/Samples.WinForms.MultiplePlayers/App.config
+++ b/src/Samples/Samples.WinForms.MultiplePlayers/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
     </startup>
 </configuration>

--- a/src/Samples/Samples.WinForms.MultiplePlayers/App.config
+++ b/src/Samples/Samples.WinForms.MultiplePlayers/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/src/Samples/Samples.WinForms.MultiplePlayers/Samples.WinForms.MultiplePlayers.csproj
+++ b/src/Samples/Samples.WinForms.MultiplePlayers/Samples.WinForms.MultiplePlayers.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Samples.WinForms.MultiplePlayers</RootNamespace>
     <AssemblyName>Samples.WinForms.MultiplePlayers</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/src/Samples/Samples.WinForms.MultiplePlayers/Samples.WinForms.MultiplePlayers.csproj
+++ b/src/Samples/Samples.WinForms.MultiplePlayers/Samples.WinForms.MultiplePlayers.csproj
@@ -8,12 +8,13 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Samples.WinForms.MultiplePlayers</RootNamespace>
     <AssemblyName>Samples.WinForms.MultiplePlayers</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_set.cs
+++ b/src/Vlc.DotNet.Core.Interops/Signatures/libvlc_media_player.h/libvlc_audio_output_set.cs
@@ -8,5 +8,5 @@ namespace Vlc.DotNet.Core.Interops.Signatures
     /// </summary>
     [LibVlcFunction("libvlc_audio_output_set")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SetAudioOutput(IntPtr mediaPlayerInstance, Utf8StringHandle audioOutputName);
+    internal delegate int SetAudioOutput(IntPtr mediaPlayerInstance, Utf8StringHandle audioOutputName);
 }

--- a/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutput.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcManager.SetAudioOutput.cs
@@ -5,18 +5,18 @@ namespace Vlc.DotNet.Core.Interops
 {
     public sealed partial class VlcManager
     {
-        public void SetAudioOutput(AudioOutputDescriptionStructure output)
+        public int SetAudioOutput(VlcMediaPlayerInstance mediaPlayerInstance, AudioOutputDescriptionStructure output)
         {
-            SetAudioOutput(output.Name);
+            return SetAudioOutput(mediaPlayerInstance, output.Name);
         }
 
-        public void SetAudioOutput(string outputName)
+        public int SetAudioOutput(VlcMediaPlayerInstance mediaPlayerInstance, string outputName)
         {
             EnsureVlcInstance();
 
             using (var outputInterop = Utf8InteropStringConverter.ToUtf8StringHandle(outputName))
             {
-                GetInteropDelegate<SetAudioOutput>().Invoke(myVlcInstance, outputInterop);
+                return GetInteropDelegate<SetAudioOutput>().Invoke(mediaPlayerInstance, outputInterop);
             }
         }
     }

--- a/src/Vlc.DotNet.Core/AudioOutputsManagement.cs
+++ b/src/Vlc.DotNet.Core/AudioOutputsManagement.cs
@@ -45,7 +45,7 @@ namespace Vlc.DotNet.Core
             {
                 throw new NotSupportedException("Not implemented in LibVlc.");
             }
-            set { myManager.SetAudioOutput(value.Name); }
+            set { myManager.SetAudioOutput(myMediaPlayerInstance, value.Name); }
         }
     }
 }

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -99,6 +99,11 @@ namespace Vlc.DotNet.Core
             set { Manager.SetMediaPlayerVideoHostHandle(myMediaPlayerInstance, value); }
         }
 
+        public int SetAudioOutput(string outputName)
+        {
+            return this.Manager.SetAudioOutput(myMediaPlayerInstance, outputName);
+        }
+
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
libvlc  crashes if i set the "waveout" audio output, other profiles (directsound, mmdevice,... ) work fine
tested on Windows7 x64, libvlc-3.0.4

Fixes #492 