### PR TITLE
Update Form1.cs VlcDirectory

### DIFF
--- a/src/Samples/Samples.WinForms.InitWithCode/Form1.cs
+++ b/src/Samples/Samples.WinForms.InitWithCode/Form1.cs
@@ -12,12 +12,7 @@ namespace Samples.WinForms.InitWithCode
         {
             InitializeComponent();
             var control = new VlcControl();
-
-
-            var currentAssembly = Assembly.GetEntryAssembly();
-            var currentDirectory = new FileInfo(currentAssembly.Location).DirectoryName;
-            // Default installation path of VideoLAN.LibVLC.Windows
-            var libDirectory = new DirectoryInfo(Path.Combine(currentDirectory, "libvlc", IntPtr.Size == 4 ? "win-x86" : "win-x64"));
+            var libDirectory = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory + @"libvlc\" + IntPtr.Size == 4 ? "win-x86" : "win-x64");
 
             control.BeginInit();
             control.VlcLibDirectory = libDirectory;


### PR DESCRIPTION
No need to use too long strings for just finding current directory,
Visit for Getting current directory: https://stackoverflow.com/a/34648431/11390822
Path.combine sometimes gives errors.
You can add this string to your other samples as well.
Thanks I love Vlc.dotnet