### PR TITLE
Disposing many viewers at once fixes

### DIFF
--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.Events.Log.cs
@@ -61,9 +61,9 @@ namespace Vlc.DotNet.Core
                 var utf8Buffer = Marshal.AllocHGlobal(byteLength);
 
                 string formattedDecodedMessage;
-                try {
+                try 
+                {
                     Win32Interops.vsprintf(utf8Buffer, format, args);
-
                     formattedDecodedMessage = Utf8InteropStringConverter.Utf8InteropToString(utf8Buffer);
                 }
                 finally
@@ -78,11 +78,16 @@ namespace Vlc.DotNet.Core
 
                 // Do the notification on another thread, so that VLC is not interrupted by the logging
 #if NETSTANDARD1_3 || NETSTANDARD2_0 || NET45
-                Task.Run(() => this.log(this.myMediaPlayerInstance, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line)));
+                Task.Run(() => 
+                {
+                    if(this.log != null)
+                        this.log(this.myMediaPlayerInstance, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line));
+                });
 #else
                 ThreadPool.QueueUserWorkItem(eventArgs =>
                 {
-                    this.log(this.myMediaPlayerInstance, (VlcMediaPlayerLogEventArgs)eventArgs);
+                    if (this.log != null)
+                        this.log(this.myMediaPlayerInstance, (VlcMediaPlayerLogEventArgs)eventArgs);
                 }, new VlcMediaPlayerLogEventArgs(level, formattedDecodedMessage, module, file, line));
 #endif
             }


### PR DESCRIPTION
I have a use-case where I open many viewers (6-9) at once and when I'm done, I dispose of them all too. I encountered two exceptions. 

Issue #639 -- a null reference exception
Issue #640 -- an index out of range exception

I believe this pull request fixes both those issues because I've been using the modified .dlls in my solution for a few days without these exceptions reoccurring.